### PR TITLE
removed called_by_minimizer since it isn't needed

### DIFF
--- a/src/easydiffraction/analysis/calculators/calculator_base.py
+++ b/src/easydiffraction/analysis/calculators/calculator_base.py
@@ -24,8 +24,7 @@ class CalculatorBase(ABC):
 
     def calculate_pattern(self,
                           sample_models,
-                          experiment,
-                          called_by_minimizer=False):
+                          experiment):
         # Multiple sample models, single experiment
 
         x_data = experiment.datastore.pattern.x
@@ -41,8 +40,7 @@ class CalculatorBase(ABC):
             sample_model = sample_models[sample_model_id]
 
             sample_model_y_calc = self._calculate_single_model_pattern(sample_model,
-                                                                       experiment,
-                                                                       called_by_minimizer=called_by_minimizer)
+                                                                       experiment)
 
             sample_model_y_calc_scaled = sample_model_scale * sample_model_y_calc
             y_calc_scaled += sample_model_y_calc_scaled
@@ -60,8 +58,7 @@ class CalculatorBase(ABC):
     @abstractmethod
     def _calculate_single_model_pattern(self,
                                         sample_model,
-                                        experiment,
-                                        called_by_minimizer):
+                                        experiment):
         pass
 
     def _get_valid_linked_phases(self, sample_models, experiment):

--- a/src/easydiffraction/analysis/calculators/calculator_crysfml.py
+++ b/src/easydiffraction/analysis/calculators/calculator_crysfml.py
@@ -25,8 +25,7 @@ class CrysfmlCalculator(CalculatorBase):
 
     def _calculate_single_model_pattern(self,
                                         sample_model,
-                                        experiment,
-                                        called_by_minimizer=False):
+                                        experiment):
         """
         Calculates the diffraction pattern using Crysfml for the given sample model and experiment.
         """

--- a/src/easydiffraction/analysis/calculators/calculator_cryspy.py
+++ b/src/easydiffraction/analysis/calculators/calculator_cryspy.py
@@ -33,22 +33,16 @@ class CryspyCalculator(CalculatorBase):
 
     def _calculate_single_model_pattern(self,
                                         sample_model,
-                                        experiment,
-                                        called_by_minimizer=False):
+                                        experiment):
         # TODO: We need to avoid re-creating the cryspy object every time.
         # Instead, we should update the cryspy_dict with the new sample model
         # and experiment. Expected to speed up the calculation 10 times!
 
         #_cryspy_expt_id = experiment.id
         #_is_cryspy_dict = bool(self._cryspy_dict)
-        #_called_by_minimizer = called_by_minimizer
 
-        if called_by_minimizer:
-            if self._cryspy_dicts and experiment.id in self._cryspy_dicts:
-                cryspy_dict = self._recreate_cryspy_dict(sample_model, experiment)
-            else:
-                cryspy_obj = self._recreate_cryspy_obj(sample_model, experiment)
-                cryspy_dict = cryspy_obj.get_dictionary()
+        if self._cryspy_dicts and experiment.id in self._cryspy_dicts:
+            cryspy_dict = self._recreate_cryspy_dict(sample_model, experiment)
         else:
             cryspy_obj = self._recreate_cryspy_obj(sample_model, experiment)
             cryspy_dict = cryspy_obj.get_dictionary()

--- a/src/easydiffraction/analysis/calculators/calculator_pdffit.py
+++ b/src/easydiffraction/analysis/calculators/calculator_pdffit.py
@@ -25,7 +25,6 @@ class PdffitCalculator(CalculatorBase):
 
     def _calculate_single_model_pattern(self,
                                         sample_model,
-                                        experiment,
-                                        called_by_minimizer=False):
+                                        experiment):
         print("[PdfFit] Not implemented yet.")
         return []

--- a/src/easydiffraction/analysis/minimization.py
+++ b/src/easydiffraction/analysis/minimization.py
@@ -61,8 +61,8 @@ class DiffractionMinimizer:
         residuals = []
         for expt_id, experiment in experiments._items.items():
             y_calc = calculator.calculate_pattern(sample_models,
-                                                  experiment,
-                                                  called_by_minimizer=True)  # True False
+                                                  experiment)
+
             y_meas = experiment.datastore.pattern.meas
             y_meas_su = experiment.datastore.pattern.meas_su
             diff = (y_meas - y_calc) / y_meas_su


### PR DESCRIPTION
The argument `called_by_minimizer`, passed around minimizers and calculators, is not needed.
The target conditional in the calculator can be simplified.

The test before/after show no decrease in performance.
