### PR TITLE
Release: merge develop into master

### DIFF
--- a/.badgery.yaml
+++ b/.badgery.yaml
@@ -63,11 +63,11 @@ cards:
   - group: Build & Release
     type: gh_action
     title: Publishing (PyPI)
-    workflow: pypi-publish.yml
+    workflow: pypi-publish.yaml
     enabled: true
 
   - group: Build & Release
     type: gh_action
     title: Docs build/deployment
-    workflow: docs.yml
+    workflow: docs.yaml
     enabled: true


### PR DESCRIPTION
⚠️ This PR is created automatically to trigger the release pipeline. It merges the accumulated changes from `develop` into `master`.

  It is labeled `[maintainer] auto-pull-request` and is excluded from release notes and version bump logic.