### PR TITLE
Add Gauss/Lorentz model switch to Becker-Coppens extinction

### DIFF
--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -1,0 +1,377 @@
+# EasyDiffraction Development Roadmap
+
+LIB – Python library API  
+APP – graphical application  
+CLI – command-line interface
+
+Legend:
+
+- ✅ done
+- 🚧 work in progress
+- 🗓 planned
+  - 🗓`highest` Urgent. Needs attention ASAP
+  - 🗓`high` Should be prioritized soon
+  - 🗓`medium` Normal/default priority
+  - 🗓`low` Low importance
+  - 🗓`lowest` Very low urgency
+- — not applicable / not implemented
+
+---
+
+# 1. Sample Model
+
+## 1.1 Crystal Structure Parameters
+
+### Space Group
+
+| Feature                            | LIB | APP |
+| ---------------------------------- | --- | --- |
+| Hermann-Mauguin space-group symbol | ✅  | ✅  |
+| Space group IT number              | 🗓  | 🗓  |
+| IT coordinate system code          | ✅  | ✅  |
+
+### Cell
+
+| Feature           | LIB | APP |
+| ----------------- | --- | --- |
+| Lengths _a, b, c_ | ✅  | ✅  |
+| Angles _α, β, γ_  | ✅  | ✅  |
+
+### Atom Sites
+
+| Feature                                        | LIB | APP |
+|------------------------------------------------| --- | --- |
+| Neutron scattering lengths (tabulated, CrysPy) | ✅  | ✅  |
+| X-ray scattering factors (tabulated, CrysPy)   | ✅  | ✅  |
+| Custom neutron scattering length               | 🗓  | 🗓  |
+| Fractional coordinates _x, y, z_               | ✅  | ✅  |
+| Occupancy                                      | ✅  | ✅  |
+| Symmetry _wyckoff_letter_                      | ✅  | ✅  |
+
+### Atomic Displacement Parameters (ADP)
+
+| Feature                                         | LIB         | APP |
+| ----------------------------------------------- | ----------- | --- |
+| Isotropic Biso                                  | ✅          | 🗓  |
+| Isotropic Uiso                                  | 🗓          | ✅  |
+| Anisotropic Bani _B11, B22, B33, B12, B13, B23_ | 🗓`highest` | 🗓  |
+| Anisotropic Uani _U11, U22, U33, U12, U13, U23_ | 🗓          | 🗓  |
+
+---
+
+## 1.2 Magnetic Structure Parameters
+
+| Feature                                                 | LIB | APP |
+| ------------------------------------------------------- | --- | --- |
+| EPIC (Magnetic space groups, unpolarized and polarized) | 🗓  | 🗓  |
+
+---
+
+# 2. Experiment Model
+
+## 2.1 Powder Diffraction
+
+### Fitting Methods
+
+| Feature                               | LIB | APP |
+| ------------------------------------- | --- | --- |
+| Rietveld refinement (full pattern)    | ✅  | ✅  |
+| Le Bail refinement (profile matching) | 🗓  | 🗓  |
+
+### Linked Phases
+
+| Feature      | LIB | APP |
+| ------------ | --- | --- |
+| Scale factor | ✅  | ✅  |
+
+### Excluded Regions
+
+| Feature                                   | LIB | APP |
+| ----------------------------------------- | --- | --- |
+| Multiple regions<br>_start/end positions_ | ✅  | 🗓  |
+
+---
+
+### Background
+
+| Feature                                           | LIB | APP |
+| ------------------------------------------------- | --- | --- |
+| Line segments type<br>_x, y_                      | ✅  | ✅  |
+| Chebyshev polynomial type<br>_order, coefficient_ | ✅  | 🗓  |
+
+### Preferred Orientation
+
+| Feature                                    | LIB      | APP |
+| ------------------------------------------ | -------- | --- |
+| Basic preferred orientation model (CrysPy) | 🗓`high` | 🗓  |
+
+### Instrument — Constant Wavelength
+
+| Feature                                       | LIB | APP |
+| --------------------------------------------- | --- | --- |
+| Wavelength                                    | ✅  | ✅  |
+| Second wavelength                             | 🚧  | 🗓  |
+| 2θ offset                                     | ✅  | ✅  |
+| Sample displacement correction _SyCos, SySin_ | 🚧  | 🗓  |
+
+### Instrument — Time-of-Flight
+
+| Feature                                                       | LIB | APP |
+| ------------------------------------------------------------- | --- | --- |
+| 2θ bank                                                       | ✅  | ✅  |
+| d → TOF conversion<br>_reciprocal, offset, linear, quadratic_ | ✅  | ✅  |
+
+### Peak Profile — Constant Wavelength
+
+CrysPy: Pseudo-Voigt from FullProf.
+Empirical asymmetry, 4 params (p1, p2, p3, p4) from FullProf.
+
+| Feature                                                                                                                                                                            | LIB  | APP |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------| --- |
+| Pseudo-Voigt + Empirical asymmetry<br>_Gaussian broadening U, V, W. Lorentzian broadening X, Y<br>Empirical asymmetry p1, p2, p3, p4_<br>(CrysPy)                                  | ✅    | ✅  |
+| Thompson-Cox-Hastings Pseudo-Voigt + Finger-Cox-Jephcoat asymmetry<br>_Gaussian broadening U, V, W. Lorentzian broadening X, Y<br>Finger-Cox-Jephcoat asymmetry 1, 2_<br>(CrysFML) | ✅/🗓 | 🗓  |
+
+### Peak Profile — Time-of-Flight
+
+CrysPy peak_shape options:
+- "Gauss": Jorgensen (back-to-back exponentials ⊗ Gaussian)
+- "pseudo-Voigt": Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)
+- "type0m": Double back-to-back exponentials ⊗ pseudo-Voigt (Z-Rietveld type 0m)
+
+| Feature                                                                                                                                                                                                                            | LIB | APP |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| - | -- |
+| Jorgensen (back-to-back exponentials ⊗ Gaussian)<br>_Gaussian broadening σ₀, σ₁, σ₂<br>Back-to-back exponential rise α₀, α₁. Back-to-back exponential decay β₀, β₁_<br>(CrysPy)                                                    | ✅ | ✅ |
+| Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)<br>_Gaussian broadening σ₀, σ₁, σ₂. Lorentzian broadening γ₀, γ₁, γ₂<br>Back-to-back exponential rise α₀, α₁. Back-to-back exponential decay β₀, β₁_<br>(CrysPy)   | 🗓 | ✅ |
+| Double back-to-back exponentials ⊗ pseudo-Voigt [Z-Rietveld type0m]<br>_Gaussian broadening σ₀, σ₁, σ₂. Lorentzian broadening γ₀, γ₁, γ₂<br>Rise α₁, α₂. Fast decay β₀₀, β₀₁. Slow decay β₁₀. Switching r₀₁, r₀₂, r₀₃_<br>(CrysPy) | 🗓 | 🗓  |
+
+| TOF profile                                                          | TOF source                                                        | Performance |
+| -------------------------------------------------------------------- |-------------------------------------------------------------------| ---------- |
+| Jorgensen (back-to-back exponentials ⊗ Gaussian)                     | Simpler TOF profile, including reactor-source TOF implementations | Fast       |
+| Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)      | Spallation-source TOF                                             | Slower       |
+| Double back-to-back exponentials ⊗ pseudo-Voigt (Z-Rietveld type0m)  | Spallation-source TOF; more elaborate asymmetric profile          | Slowest           |
+
+---
+
+## 2.1.2 Total Scattering (Pair Distribution Function)
+
+### Peak Profile
+
+| Feature                                                                                                | LIB | APP |
+| ------------------------------------------------------------------------------------------------------ | --- | --- |
+| GaussianDampedSinc type<br>_cutoff q. broadening q. sharpening δ₁, δ₂<br>damping q, particle diameter_ | ✅  | 🗓  |
+
+---
+
+## 2.2 Single Crystal Diffraction
+
+### Extinction
+
+CrysPy's extinction is NOT Shelx-style. It's an analytical Becker-Coppens spherical model with 
+Gauss or Lorentz mosaicity distribution
+
+| Feature                               | LIB | APP |
+| ------------------------------------- | --- | --- |
+| Gaussian model: _radius, mosaicity_   | ✅  | ✅  |
+| Lorentzian model: _radius, mosaicity_ | ✅  | ✅  |
+
+### Domains / Twinning
+
+| Feature                                           | LIB | APP |
+| ------------------------------------------------- | --- | --- |
+| Twinning / domains for single-crystal diffraction | 🗓  | 🗓  |
+
+### Instrument — Constant Wavelength
+
+| Feature               | LIB | APP |
+| --------------------- | --- | --- |
+| Wavelength            | ✅  | ✅  |
+| Half wavelength (λ/2) | 🗓  | 🗓  |
+
+### Instrument — Time-of-Flight
+
+| Feature                              | LIB | APP |
+| ------------------------------------ | --- | --- |
+| Individual wavelength per reflection | ✅  | 🗓  |
+
+## 2.3. Polarized Neutron Diffraction
+
+| Feature                                        | LIB | APP |
+| ---------------------------------------------- | --- | --- |
+| EPIC (powders and single crystals, FR and SNP) | 🗓  | 🗓  |
+
+---
+
+# 3. Multi-Dataset Support
+
+| Feature                           | LIB | APP |
+| --------------------------------- | --- | --- |
+| Multiple structural data blocks   | ✅  | ✅  |
+| Multiple experimental data blocks | ✅  | 🗓  |
+
+---
+
+# 4. Analysis (Fitting)
+
+### Refinement Algorithms
+
+| Feature                                                         | LIB | APP |
+| --------------------------------------------------------------- | --- | --- |
+| Levenberg–Marquardt (numerical derivatives)<br>LMFIT minimizer  | ✅  | ✅  |
+| Levenberg–Marquardt (analytical derivatives)<br>LMFIT minimizer | 🗓  | 🗓  |
+| Derivative-free minimization<br>DFO-LS minimizer                | ✅  | ✅  |
+| Bayesian analysis<br>BUMPS minimizer                            | 🗓  | 🗓  |
+
+### Fit Strategies
+
+| Feature                                                                                              | LIB | APP |
+| ---------------------------------------------------------------------------------------------------- | --- | --- |
+| Sequential fit of experimental data blocks                                                           | ✅  | 🗓  |
+| Joint fit of experimental data blocks within the same calculation engine                             | ✅  | 🗓  |
+| Joint fit of experimental data blocks using different calculation engines<br>(e.g. CrysPy + Pdffit2) | ✅  | 🗓  |
+| Custom weighting for joint fit: _weight per dataset_                                                 | ✅  | 🗓  |
+
+### Live Fitting
+
+| Feature                                        | LIB | APP |
+| ---------------------------------------------- | --- | --- |
+| Live fitting during real-time data acquisition | 🗓  | 🗓  |
+
+---
+
+# 5. Refinement Execution
+
+| Feature                                       | LIB | APP | CLI |
+| --------------------------------------------- | --- | --- | --- |
+| Scripted refinement workflow                  | ✅  | —   | —   |
+| GUI-driven refinement workflow                | —   | ✅  | —   |
+| Command-line refinement execution             | —   | —   | ✅  |
+| Parameter modification                        | ✅  | ✅  | —   |
+| Load individual structure or experiment files | ✅  | ✅  | —   |
+| Project-based refinement                      | ✅  | ✅  | ✅  |
+| Save refinement results to project            | ✅  | ✅  | ✅  |
+
+---
+
+# 6. Constraints
+
+| Feature                        | LIB | APP   |
+| ------------------------------ | --- | ----- |
+| Automatic symmetry constraints | ✅  | ✅/🗓 |
+| User-defined constraints       | ✅  | 🗓    |
+
+---
+
+# 7. Data Management
+
+### Data Loading
+
+| Feature                         | LIB | APP | CLI |
+| ------------------------------- | --- | --- | --- |
+| Load structure from CIF         | ✅  | ✅  | —   |
+| Load experiment data from ASCII | ✅  | ✅  | —   |
+| Load experiment data from CIF   | ✅  | ✅  | —   |
+
+### Project Files
+
+| Feature                | LIB | APP | CLI |
+| ---------------------- | --- | --- | --- |
+| Load project from disk | 🚧  | ✅  | 🗓  |
+| Save project to disk   | ✅  | ✅  | 🗓  |
+
+### SciCat Integration
+
+| Feature                  | LIB | APP | CLI |
+| ------------------------ | --- | --- | --- |
+| Load project from SciCat | 🗓  | 🗓  | —   |
+| Save project to SciCat   | 🗓  | 🗓  | —   |
+
+### External Resources
+
+| Feature                           | LIB | APP | CLI |
+| --------------------------------- | --- | --- | --- |
+| List available tutorial notebooks | —   | —   | ✅  |
+| Download tutorial notebooks       | —   | —   | ✅  |
+
+---
+
+# 8. Visualization
+
+## 8.1. Sample Model
+
+### Crystal Structure
+
+| Feature                                  | LIB | APP |
+| ---------------------------------------- | --- |-----|
+| Visualize unit cell                      | 🗓  | ✅/🗓  |
+| Visualize multiple unit cells            | 🗓  | 🗓  |
+| Visualize atom sites as spheres          | 🗓  | ✅   |
+| Visualize atoms occupied same position   | 🗓  | 🗓  |
+| Interactive mode<br>3D rotation, zooming | 🗓  | ✅   |
+| Orthogonal unit cell                     | 🗓  | ✅   |
+| Non-orthogonal unit cell                 | 🗓  | 🗓  |
+
+### Magnetic Structure
+
+| Feature                              | LIB | APP |
+| ------------------------------------ | --- | --- |
+| Visualize magnetic moments as arrows | 🗓  | 🗓  |
+
+## 8.2. Experiment
+
+### Powder Diffraction
+
+| Feature                              | LIB      | APP | CLI |
+| ------------------------------------ | -------- | --- | --- |
+| Plot experimental curve              | ✅       | ✅  | ✅  |
+| Plot calculated curve                | ✅       | ✅  | ✅  |
+| Plot residual curve                  | ✅       | ✅  | ✅  |
+| Plot Bragg peaks                     | 🗓`high` | ✅  | —   |
+| Interactive mode<br>zooming, panning | ✅       | ✅  | —   |
+
+### Single Crystal Diffraction
+
+| Feature                              | LIB | APP | CLI |
+| ------------------------------------ | --- | --- | --- |
+| Plot obs vs calc for reflections     | ✅  | ✅  | ✅  |
+| Interactive mode<br>zooming, panning | ✅  | ✅  | —   |
+
+## 8.3. Analysis
+
+| Feature                                              | LIB | APP | CLI |
+| ---------------------------------------------------- |-----| --- | --- |
+| Live update of plots on parameter change with slider | —   | ✅  | —   |
+| Live update of plots during refinement               | —   | ✅  | —   |
+| Parameter evolution (sequential refinement)          | ✅/🗓  | 🗓  | —   |
+
+### Fitting
+
+| Feature                                   | LIB | APP | CLI |
+| ----------------------------------------- | --- | --- | --- |
+| Live update of plots                      | —   | ✅  | —   |
+| Live update of fit quality (change in χ²) | ✅  | ✅  | ✅  |
+| Plot correlation between parameters       | ✅  | 🗓  | —   |
+
+---
+
+# 9. User documentation
+
+| Feature                             | LIB | APP   |
+| ----------------------------------- | --- | ----- |
+| New unified documentation structure | ✅  | 🗓    |
+| Introduction                        | ✅  | ✅/🗓 |
+| Installation and setup guide        | ✅  | ✅/🗓 |
+| User guide                          | ✅  | ✅/🗓 |
+| Tutorials                           | ✅  | 🗓    |
+| API reference                       | ✅  | —     |
+
+---
+
+# 10. Future Topics
+
+Here, we list features that are not sorted into the above categories, but are
+still on our radar for future development.
+
+- Restrains (soft constraints, e.g. bond lengths, angles)
+- Global optimization algorithms (e.g. simulated annealing)
+- Incommensurate structures
+- 2D Rietveld refinement

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -40,7 +40,7 @@ Legend:
 ### Atom Sites
 
 | Feature                                        | LIB | APP |
-|------------------------------------------------| --- | --- |
+| ---------------------------------------------- | --- | --- |
 | Neutron scattering lengths (tabulated, CrysPy) | ✅  | ✅  |
 | X-ray scattering factors (tabulated, CrysPy)   | ✅  | ✅  |
 | Custom neutron scattering length               | 🗓  | 🗓  |
@@ -107,12 +107,12 @@ Legend:
 
 ### Instrument — Constant Wavelength
 
-| Feature                                       | LIB | APP |
-| --------------------------------------------- | --- | --- |
-| Wavelength                                    | ✅  | ✅  |
-| Second wavelength                             | 🚧  | 🗓  |
-| 2θ offset                                     | ✅  | ✅  |
-| Sample displacement correction _SyCos, SySin_ | 🚧  | 🗓  |
+| Feature                                                  | LIB | APP |
+| -------------------------------------------------------- | --- | --- |
+| Wavelength                                               | ✅  | ✅  |
+| Second wavelength                                        | 🚧  | 🗓  |
+| 2θ offset                                                | ✅  | ✅  |
+| Sample displacement correction (FullProf _SyCos, SySin_) | 🚧  | 🗓  |
 
 ### Instrument — Time-of-Flight
 
@@ -123,32 +123,35 @@ Legend:
 
 ### Peak Profile — Constant Wavelength
 
-CrysPy: Pseudo-Voigt from FullProf.
-Empirical asymmetry, 4 params (p1, p2, p3, p4) from FullProf.
+CrysPy: Pseudo-Voigt from FullProf. Empirical asymmetry, 4 params (p1,
+p2, p3, p4) from FullProf.
 
-| Feature                                                                                                                                                                            | LIB  | APP |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------| --- |
+| Feature                                                                                                                                                                            | LIB   | APP |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | --- |
 | Pseudo-Voigt + Empirical asymmetry<br>_Gaussian broadening U, V, W. Lorentzian broadening X, Y<br>Empirical asymmetry p1, p2, p3, p4_<br>(CrysPy)                                  | ✅    | ✅  |
 | Thompson-Cox-Hastings Pseudo-Voigt + Finger-Cox-Jephcoat asymmetry<br>_Gaussian broadening U, V, W. Lorentzian broadening X, Y<br>Finger-Cox-Jephcoat asymmetry 1, 2_<br>(CrysFML) | ✅/🗓 | 🗓  |
 
 ### Peak Profile — Time-of-Flight
 
 CrysPy peak_shape options:
+
 - "Gauss": Jorgensen (back-to-back exponentials ⊗ Gaussian)
-- "pseudo-Voigt": Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)
-- "type0m": Double back-to-back exponentials ⊗ pseudo-Voigt (Z-Rietveld type 0m)
+- "pseudo-Voigt": Jorgensen-Von Dreele (back-to-back exponentials ⊗
+  pseudo-Voigt)
+- "type0m": Double back-to-back exponentials ⊗ pseudo-Voigt (Z-Rietveld
+  type 0m)
 
 | Feature                                                                                                                                                                                                                            | LIB | APP |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| - | -- |
-| Jorgensen (back-to-back exponentials ⊗ Gaussian)<br>_Gaussian broadening σ₀, σ₁, σ₂<br>Back-to-back exponential rise α₀, α₁. Back-to-back exponential decay β₀, β₁_<br>(CrysPy)                                                    | ✅ | ✅ |
-| Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)<br>_Gaussian broadening σ₀, σ₁, σ₂. Lorentzian broadening γ₀, γ₁, γ₂<br>Back-to-back exponential rise α₀, α₁. Back-to-back exponential decay β₀, β₁_<br>(CrysPy)   | 🗓 | ✅ |
-| Double back-to-back exponentials ⊗ pseudo-Voigt [Z-Rietveld type0m]<br>_Gaussian broadening σ₀, σ₁, σ₂. Lorentzian broadening γ₀, γ₁, γ₂<br>Rise α₁, α₂. Fast decay β₀₀, β₀₁. Slow decay β₁₀. Switching r₀₁, r₀₂, r₀₃_<br>(CrysPy) | 🗓 | 🗓  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | --- |
+| Jorgensen (back-to-back exponentials ⊗ Gaussian)<br>_Gaussian broadening σ₀, σ₁, σ₂<br>Back-to-back exponential rise α₀, α₁. Back-to-back exponential decay β₀, β₁_<br>(CrysPy)                                                    | ✅  | ✅  |
+| Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)<br>_Gaussian broadening σ₀, σ₁, σ₂. Lorentzian broadening γ₀, γ₁, γ₂<br>Back-to-back exponential rise α₀, α₁. Back-to-back exponential decay β₀, β₁_<br>(CrysPy)   | 🗓  | ✅  |
+| Double back-to-back exponentials ⊗ pseudo-Voigt [Z-Rietveld type0m]<br>_Gaussian broadening σ₀, σ₁, σ₂. Lorentzian broadening γ₀, γ₁, γ₂<br>Rise α₁, α₂. Fast decay β₀₀, β₀₁. Slow decay β₁₀. Switching r₀₁, r₀₂, r₀₃_<br>(CrysPy) | 🗓  | 🗓  |
 
-| TOF profile                                                          | TOF source                                                        | Performance |
-| -------------------------------------------------------------------- |-------------------------------------------------------------------| ---------- |
-| Jorgensen (back-to-back exponentials ⊗ Gaussian)                     | Simpler TOF profile, including reactor-source TOF implementations | Fast       |
-| Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)      | Spallation-source TOF                                             | Slower       |
-| Double back-to-back exponentials ⊗ pseudo-Voigt (Z-Rietveld type0m)  | Spallation-source TOF; more elaborate asymmetric profile          | Slowest           |
+| TOF profile                                                         | TOF source                                                        | Performance |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------- |
+| Jorgensen (back-to-back exponentials ⊗ Gaussian)                    | Simpler TOF profile, including reactor-source TOF implementations | Fast        |
+| Jorgensen-Von Dreele (back-to-back exponentials ⊗ pseudo-Voigt)     | Spallation-source TOF                                             | Slower      |
+| Double back-to-back exponentials ⊗ pseudo-Voigt (Z-Rietveld type0m) | Spallation-source TOF; more elaborate asymmetric profile          | Slowest     |
 
 ---
 
@@ -166,13 +169,15 @@ CrysPy peak_shape options:
 
 ### Extinction
 
-CrysPy's extinction is NOT Shelx-style. It's an analytical Becker-Coppens spherical model with 
-Gauss or Lorentz mosaicity distribution
+CrysPy's extinction is NOT Shelx-style. It's an analytical
+Becker-Coppens spherical model with Gauss or Lorentz mosaicity
+distribution
 
-| Feature                               | LIB | APP |
-| ------------------------------------- | --- | --- |
-| Gaussian model: _radius, mosaicity_   | ✅  | ✅  |
-| Lorentzian model: _radius, mosaicity_ | ✅  | ✅  |
+| Feature                                               | LIB | APP |
+| ----------------------------------------------------- | --- | --- |
+| Becker-Coppens, Gaussian model: _radius, mosaicity_   | ✅  | ✅  |
+| Becker-Coppens, Lorentzian model: _radius, mosaicity_ | ✅  | ✅  |
+| Anisotropic extinction correction                     | 🗓  | 🗓  |
 
 ### Domains / Twinning
 
@@ -275,8 +280,8 @@ Gauss or Lorentz mosaicity distribution
 
 | Feature                | LIB | APP | CLI |
 | ---------------------- | --- | --- | --- |
-| Load project from disk | 🚧  | ✅  | 🗓  |
-| Save project to disk   | ✅  | ✅  | 🗓  |
+| Load project from disk | ✅  | ✅  | ✅  |
+| Save project to disk   | ✅  | ✅  | ✅  |
 
 ### SciCat Integration
 
@@ -301,13 +306,15 @@ Gauss or Lorentz mosaicity distribution
 ### Crystal Structure
 
 | Feature                                  | LIB | APP |
-| ---------------------------------------- | --- |-----|
-| Visualize unit cell                      | 🗓  | ✅/🗓  |
+| ---------------------------------------- | --- | --- |
+| Visualize unit cell                      | 🗓  | ✅  |
 | Visualize multiple unit cells            | 🗓  | 🗓  |
-| Visualize atom sites as spheres          | 🗓  | ✅   |
+| Visualize atom sites as spheres          | 🗓  | ✅  |
 | Visualize atoms occupied same position   | 🗓  | 🗓  |
-| Interactive mode<br>3D rotation, zooming | 🗓  | ✅   |
-| Orthogonal unit cell                     | 🗓  | ✅   |
+| Visualize bonds                          | 🗓  | 🗓  |
+| Visualize polyhedra                      | 🗓  | 🗓  |
+| Interactive mode<br>3D rotation, zooming | 🗓  | ✅  |
+| Orthogonal unit cell                     | 🗓  | ✅  |
 | Non-orthogonal unit cell                 | 🗓  | 🗓  |
 
 ### Magnetic Structure
@@ -337,11 +344,11 @@ Gauss or Lorentz mosaicity distribution
 
 ## 8.3. Analysis
 
-| Feature                                              | LIB | APP | CLI |
-| ---------------------------------------------------- |-----| --- | --- |
-| Live update of plots on parameter change with slider | —   | ✅  | —   |
-| Live update of plots during refinement               | —   | ✅  | —   |
-| Parameter evolution (sequential refinement)          | ✅/🗓  | 🗓  | —   |
+| Feature                                              | LIB   | APP | CLI |
+| ---------------------------------------------------- | ----- | --- | --- |
+| Live update of plots on parameter change with slider | —     | ✅  | —   |
+| Live update of plots during refinement               | —     | ✅  | —   |
+| Parameter evolution (sequential refinement)          | ✅/🗓 | 🗓  | —   |
 
 ### Fitting
 
@@ -349,7 +356,7 @@ Gauss or Lorentz mosaicity distribution
 | ----------------------------------------- | --- | --- | --- |
 | Live update of plots                      | —   | ✅  | —   |
 | Live update of fit quality (change in χ²) | ✅  | ✅  | ✅  |
-| Plot correlation between parameters       | ✅  | 🗓  | —   |
+| Plot correlation between parameters       | ✅  | 🗓  | ✅  |
 
 ---
 
@@ -368,8 +375,8 @@ Gauss or Lorentz mosaicity distribution
 
 # 10. Future Topics
 
-Here, we list features that are not sorted into the above categories, but are
-still on our radar for future development.
+Here, we list features that are not sorted into the above categories,
+but are still on our radar for future development.
 
 - Restrains (soft constraints, e.g. bond lengths, angles)
 - Global optimization algorithms (e.g. simulated annealing)

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -269,7 +269,7 @@ experiment.data  # CategoryCollection
 # Type-switchable — recreates the underlying object
 experiment.background_type = 'chebyshev'  # triggers BackgroundFactory.create(...)
 experiment.peak_profile_type = 'thompson-cox-hastings'  # triggers PeakFactory.create(...)
-experiment.extinction_type = 'shelx'  # triggers ExtinctionFactory.create(...)
+experiment.extinction_type = 'becker-coppens'  # triggers ExtinctionFactory.create(...)
 experiment.linked_crystal_type = 'default'  # triggers LinkedCrystalFactory.create(...)
 experiment.excluded_regions_type = 'default'  # triggers ExcludedRegionsFactory.create(...)
 experiment.linked_phases_type = 'default'  # triggers LinkedPhasesFactory.create(...)
@@ -395,7 +395,7 @@ from .line_segment import LineSegmentBackground
 | `PeakFactory`                | Peak profiles          | `CwlPseudoVoigt`, `TofPseudoVoigtIkedaCarpenter`, …         |
 | `InstrumentFactory`          | Instruments            | `CwlPdInstrument`, `TofPdInstrument`, …                     |
 | `DataFactory`                | Data collections       | `PdCwlData`, `PdTofData`, `ReflnData`, `TotalData`          |
-| `ExtinctionFactory`          | Extinction models      | `ShelxExtinction`                                           |
+| `ExtinctionFactory`          | Extinction models      | `BeckerCoppensExtinction`                                   |
 | `LinkedCrystalFactory`       | Linked-crystal refs    | `LinkedCrystal`                                             |
 | `ExcludedRegionsFactory`     | Excluded regions       | `ExcludedRegions`                                           |
 | `LinkedPhasesFactory`        | Linked phases          | `LinkedPhases`                                              |
@@ -480,9 +480,9 @@ Tags are the user-facing identifiers for selecting types. They must be:
 
 **Extinction tags**
 
-| Tag     | Class             |
-| ------- | ----------------- |
-| `shelx` | `ShelxExtinction` |
+| Tag              | Class                     |
+| ---------------- | ------------------------- |
+| `becker-coppens` | `BeckerCoppensExtinction` |
 
 **Linked-crystal tags**
 
@@ -555,7 +555,7 @@ line-segment points.
 | `TofPseudoVoigtIkedaCarpenter` | `PeakFactory`           |
 | `TofPseudoVoigtBackToBack`     | `PeakFactory`           |
 | `TotalGaussianDampedSinc`      | `PeakFactory`           |
-| `ShelxExtinction`              | `ExtinctionFactory`     |
+| `BeckerCoppensExtinction`      | `ExtinctionFactory`     |
 | `LinkedCrystal`                | `LinkedCrystalFactory`  |
 | `Cell`                         | `CellFactory`           |
 | `SpaceGroup`                   | `SpaceGroupFactory`     |

--- a/docs/architecture/issues_closed.md
+++ b/docs/architecture/issues_closed.md
@@ -92,8 +92,8 @@ pattern. Each former single-file category is now a package with
 class with `@register` + `type_info`), and `__init__.py` (re-exports
 preserving import compatibility).
 
-Experiment categories: `Extinction` → `ShelxExtinction` /
-`ExtinctionFactory` (tag `shelx`), `LinkedCrystal` /
+Experiment categories: `Extinction` → `BeckerCoppensExtinction` /
+`ExtinctionFactory` (tag `becker-coppens`), `LinkedCrystal` /
 `LinkedCrystalFactory` (tag `default`), `ExcludedRegions` /
 `ExcludedRegionsFactory`, `LinkedPhases` / `LinkedPhasesFactory`,
 `ExperimentType` / `ExperimentTypeFactory`.
@@ -105,7 +105,7 @@ Analysis categories: `Aliases` / `AliasesFactory`, `Constraints` /
 `ConstraintsFactory`, `JointFitExperiments` /
 `JointFitExperimentsFactory`.
 
-`ShelxExtinction` and `LinkedCrystal` get the full switchable-category
+`BeckerCoppensExtinction` and `LinkedCrystal` get the full switchable-category
 API on `ScExperimentBase` (`extinction_type`, `linked_crystal_type`
 getter+setter, `show_supported_*_types()`, `show_current_*_type()`).
 `ExcludedRegions` and `LinkedPhases` get the same API on

--- a/docs/architecture/issues_closed.md
+++ b/docs/architecture/issues_closed.md
@@ -105,12 +105,12 @@ Analysis categories: `Aliases` / `AliasesFactory`, `Constraints` /
 `ConstraintsFactory`, `JointFitExperiments` /
 `JointFitExperimentsFactory`.
 
-`BeckerCoppensExtinction` and `LinkedCrystal` get the full switchable-category
-API on `ScExperimentBase` (`extinction_type`, `linked_crystal_type`
-getter+setter, `show_supported_*_types()`, `show_current_*_type()`).
-`ExcludedRegions` and `LinkedPhases` get the same API on
-`PdExperimentBase`. `Cell`, `SpaceGroup`, and `AtomSites` get it on
-`Structure`. `Aliases` and `Constraints` get it on `Analysis`.
+`BeckerCoppensExtinction` and `LinkedCrystal` get the full
+switchable-category API on `ScExperimentBase` (`extinction_type`,
+`linked_crystal_type` getter+setter, `show_supported_*_types()`,
+`show_current_*_type()`). `ExcludedRegions` and `LinkedPhases` get the
+same API on `PdExperimentBase`. `Cell`, `SpaceGroup`, and `AtomSites`
+get it on `Structure`. `Aliases` and `Constraints` get it on `Analysis`.
 Architecture §3.3, §5.5, §5.7, §9.4, §9.5 updated. Copilot instructions
 updated with universal switchable-category scope and architecture-first
 workflow rule. Unit tests extended with factory tests for extinction and

--- a/docs/architecture/package-structure-full.md
+++ b/docs/architecture/package-structure-full.md
@@ -179,8 +179,8 @@
 │   │   │   │   ├── 📄 __init__.py
 │   │   │   │   ├── 📄 factory.py
 │   │   │   │   │   └── 🏷️ class ExtinctionFactory
-│   │   │   │   └── 📄 shelx.py
-│   │   │   │       └── 🏷️ class ShelxExtinction
+│   │   │   │   └── 📄 becker_coppens.py
+│   │   │   │       └── 🏷️ class BeckerCoppensExtinction
 │   │   │   ├── 📁 instrument
 │   │   │   │   ├── 📄 __init__.py
 │   │   │   │   ├── 📄 base.py

--- a/docs/architecture/package-structure-short.md
+++ b/docs/architecture/package-structure-short.md
@@ -92,7 +92,7 @@
 │   │   │   ├── 📁 extinction
 │   │   │   │   ├── 📄 __init__.py
 │   │   │   │   ├── 📄 factory.py
-│   │   │   │   └── 📄 shelx.py
+│   │   │   │   └── 📄 becker_coppens.py
 │   │   │   ├── 📁 instrument
 │   │   │   │   ├── 📄 __init__.py
 │   │   │   │   ├── 📄 base.py

--- a/src/easydiffraction/analysis/calculators/cryspy.py
+++ b/src/easydiffraction/analysis/calculators/cryspy.py
@@ -552,7 +552,7 @@ def _cif_extinction_section(
         'mosaicity': '_extinction_mosaicity',
         'radius': '_extinction_radius',
     }
-    cif_lines.extend(('', '_extinction_model gauss'))
+    cif_lines.extend(('', f'_extinction_model {extinction.model.value}'))
     for local_attr_name, engine_key_name in extinction_mapping.items():
         attr_obj = getattr(extinction, local_attr_name)
         if attr_obj is not None:

--- a/src/easydiffraction/datablocks/experiment/categories/extinction/__init__.py
+++ b/src/easydiffraction/datablocks/experiment/categories/extinction/__init__.py
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-from easydiffraction.datablocks.experiment.categories.extinction.shelx import ShelxExtinction
+from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+    BeckerCoppensExtinction,
+)

--- a/src/easydiffraction/datablocks/experiment/categories/extinction/becker_coppens.py
+++ b/src/easydiffraction/datablocks/experiment/categories/extinction/becker_coppens.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
-"""Shelx-style isotropic extinction correction."""
+"""
+Becker-Coppens isotropic extinction correction for single crystals.
+"""
 
 from __future__ import annotations
 
@@ -8,20 +10,33 @@ from easydiffraction.core.category import CategoryItem
 from easydiffraction.core.metadata import Compatibility
 from easydiffraction.core.metadata import TypeInfo
 from easydiffraction.core.validation import AttributeSpec
+from easydiffraction.core.validation import MembershipValidator
 from easydiffraction.core.validation import RangeValidator
 from easydiffraction.core.variable import Parameter
+from easydiffraction.core.variable import StringDescriptor
 from easydiffraction.datablocks.experiment.categories.extinction.factory import ExtinctionFactory
+from easydiffraction.datablocks.experiment.item.enums import ExtinctionModelEnum
 from easydiffraction.datablocks.experiment.item.enums import SampleFormEnum
 from easydiffraction.io.cif.handler import CifHandler
 
 
 @ExtinctionFactory.register
-class ShelxExtinction(CategoryItem):
-    """Shelx-style extinction correction for single crystals."""
+class BeckerCoppensExtinction(CategoryItem):
+    """
+    Becker-Coppens spherical extinction correction for single crystals.
+
+    Combines primary and secondary extinction into a single correction
+    factor ``y = y_p * y_s``, following the Becker-Coppens formalism.
+    The mosaicity distribution for the secondary extinction can be
+    either Gaussian (``'gauss'``) or Lorentzian (``'lorentz'``).
+
+    Parameters are the crystal ``radius`` (in μm) and the ``mosaicity``
+    (in arc-minutes, as expected by CrysPy).
+    """
 
     type_info = TypeInfo(
-        tag='shelx',
-        description='Shelx-style isotropic extinction correction',
+        tag='becker-coppens',
+        description='Becker-Coppens isotropic extinction correction',
     )
     compatibility = Compatibility(
         sample_form=frozenset({SampleFormEnum.SINGLE_CRYSTAL}),
@@ -30,33 +45,37 @@ class ShelxExtinction(CategoryItem):
     def __init__(self) -> None:
         super().__init__()
 
+        self._model = StringDescriptor(
+            name='model',
+            description='Mosaicity distribution model (gauss or lorentz)',
+            value_spec=AttributeSpec(
+                default=ExtinctionModelEnum.default().value,
+                validator=MembershipValidator(
+                    allowed=[member.value for member in ExtinctionModelEnum],
+                ),
+            ),
+            cif_handler=CifHandler(names=['_extinction.model']),
+        )
+
         self._mosaicity = Parameter(
             name='mosaicity',
-            description='Mosaicity value for extinction correction',
-            units='deg',
+            description='Mosaicity of the crystal',
+            units='arcmin',
             value_spec=AttributeSpec(
                 default=1.0,
                 validator=RangeValidator(),
             ),
-            cif_handler=CifHandler(
-                names=[
-                    '_extinction.mosaicity',
-                ]
-            ),
+            cif_handler=CifHandler(names=['_extinction.mosaicity']),
         )
         self._radius = Parameter(
             name='radius',
-            description='Crystal radius for extinction correction',
+            description='Mean radius of the crystal',
             units='μm',
             value_spec=AttributeSpec(
                 default=1.0,
                 validator=RangeValidator(),
             ),
-            cif_handler=CifHandler(
-                names=[
-                    '_extinction.radius',
-                ]
-            ),
+            cif_handler=CifHandler(names=['_extinction.radius']),
         )
 
         self._identity.category_code = 'extinction'
@@ -66,9 +85,24 @@ class ShelxExtinction(CategoryItem):
     # ------------------------------------------------------------------
 
     @property
+    def model(self) -> StringDescriptor:
+        """
+        Mosaicity distribution model (``'gauss'`` or ``'lorentz'``).
+
+        Reading this property returns the underlying
+        ``StringDescriptor`` object. Assigning to it updates the
+        descriptor value.
+        """
+        return self._model
+
+    @model.setter
+    def model(self, value: str) -> None:
+        self._model.value = value
+
+    @property
     def mosaicity(self) -> Parameter:
         """
-        Mosaicity value for extinction correction (deg).
+        Mosaicity of the crystal (arcmin).
 
         Reading this property returns the underlying ``Parameter``
         object. Assigning to it updates the parameter value.
@@ -82,7 +116,7 @@ class ShelxExtinction(CategoryItem):
     @property
     def radius(self) -> Parameter:
         """
-        Crystal radius for extinction correction (μm).
+        Mean radius of the crystal (μm).
 
         Reading this property returns the underlying ``Parameter``
         object. Assigning to it updates the parameter value.

--- a/src/easydiffraction/datablocks/experiment/categories/extinction/factory.py
+++ b/src/easydiffraction/datablocks/experiment/categories/extinction/factory.py
@@ -13,5 +13,5 @@ class ExtinctionFactory(FactoryBase):
     """Create extinction correction models by tag."""
 
     _default_rules: ClassVar[dict] = {
-        frozenset(): 'shelx',
+        frozenset(): 'becker-coppens',
     }

--- a/src/easydiffraction/datablocks/experiment/item/base.py
+++ b/src/easydiffraction/datablocks/experiment/item/base.py
@@ -336,7 +336,7 @@ class ScExperimentBase(ExperimentBase):
         Parameters
         ----------
         new_type : str
-            Extinction tag (e.g. ``'shelx'``).
+            Extinction tag (e.g. ``'becker-coppens'``).
         """
         supported_tags = ExtinctionFactory.supported_tags()
         if new_type not in supported_tags:

--- a/src/easydiffraction/datablocks/experiment/item/enums.py
+++ b/src/easydiffraction/datablocks/experiment/item/enums.py
@@ -225,3 +225,37 @@ class PeakProfileTypeEnum(StrEnum):
         if self is PeakProfileTypeEnum.GAUSSIAN_DAMPED_SINC:
             return 'Gaussian-damped sinc profile for pair distribution function (PDF) analysis.'
         return None
+
+
+class ExtinctionModelEnum(StrEnum):
+    """Mosaicity distribution model for Becker-Coppens extinction."""
+
+    GAUSS = 'gauss'
+    LORENTZ = 'lorentz'
+
+    @classmethod
+    def default(cls) -> 'ExtinctionModelEnum':
+        """
+        Return the default extinction model (GAUSS).
+
+        Returns
+        -------
+        'ExtinctionModelEnum'
+            The default enum member.
+        """
+        return cls.GAUSS
+
+    def description(self) -> str:
+        """
+        Return a human-readable description of this extinction model.
+
+        Returns
+        -------
+        str
+            Description string for the current enum member.
+        """
+        if self is ExtinctionModelEnum.GAUSS:
+            return 'Gaussian mosaicity distribution for extinction correction.'
+        if self is ExtinctionModelEnum.LORENTZ:
+            return 'Lorentzian mosaicity distribution for extinction correction.'
+        return None

--- a/tests/unit/easydiffraction/datablocks/experiment/categories/test_extinction.py
+++ b/tests/unit/easydiffraction/datablocks/experiment/categories/test_extinction.py
@@ -5,7 +5,9 @@
 def test_module_import():
     import easydiffraction.datablocks.experiment.categories.extinction.becker_coppens as MUT
 
-    expected_module_name = 'easydiffraction.datablocks.experiment.categories.extinction.becker_coppens'
+    expected_module_name = (
+        'easydiffraction.datablocks.experiment.categories.extinction.becker_coppens'
+    )
     actual_module_name = MUT.__name__
     assert expected_module_name == actual_module_name
 

--- a/tests/unit/easydiffraction/datablocks/experiment/categories/test_extinction.py
+++ b/tests/unit/easydiffraction/datablocks/experiment/categories/test_extinction.py
@@ -3,26 +3,56 @@
 
 
 def test_module_import():
-    import easydiffraction.datablocks.experiment.categories.extinction.shelx as MUT
+    import easydiffraction.datablocks.experiment.categories.extinction.becker_coppens as MUT
 
-    expected_module_name = 'easydiffraction.datablocks.experiment.categories.extinction.shelx'
+    expected_module_name = 'easydiffraction.datablocks.experiment.categories.extinction.becker_coppens'
     actual_module_name = MUT.__name__
     assert expected_module_name == actual_module_name
 
 
 def test_extinction_defaults():
-    from easydiffraction.datablocks.experiment.categories.extinction.shelx import ShelxExtinction
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
 
-    ext = ShelxExtinction()
+    ext = BeckerCoppensExtinction()
+    assert ext.model.value == 'gauss'
     assert ext.mosaicity.value == 1.0
     assert ext.radius.value == 1.0
     assert ext._identity.category_code == 'extinction'
 
 
-def test_extinction_property_setters():
-    from easydiffraction.datablocks.experiment.categories.extinction.shelx import ShelxExtinction
+def test_extinction_model_setter():
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
 
-    ext = ShelxExtinction()
+    ext = BeckerCoppensExtinction()
+
+    ext.model = 'lorentz'
+    assert ext.model.value == 'lorentz'
+
+    ext.model = 'gauss'
+    assert ext.model.value == 'gauss'
+
+
+def test_extinction_model_invalid():
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
+
+    ext = BeckerCoppensExtinction()
+
+    ext.model = 'invalid'
+    assert ext.model.value == 'gauss'  # keeps previous value
+
+
+def test_extinction_property_setters():
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
+
+    ext = BeckerCoppensExtinction()
 
     ext.mosaicity = 0.5
     assert ext.mosaicity.value == 0.5
@@ -32,9 +62,14 @@ def test_extinction_property_setters():
 
 
 def test_extinction_cif_handler_names():
-    from easydiffraction.datablocks.experiment.categories.extinction.shelx import ShelxExtinction
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
 
-    ext = ShelxExtinction()
+    ext = BeckerCoppensExtinction()
+
+    model_cif_names = ext._model._cif_handler.names
+    assert '_extinction.model' in model_cif_names
 
     mosaicity_cif_names = ext._mosaicity._cif_handler.names
     assert '_extinction.mosaicity' in mosaicity_cif_names
@@ -44,10 +79,12 @@ def test_extinction_cif_handler_names():
 
 
 def test_extinction_type_info():
-    from easydiffraction.datablocks.experiment.categories.extinction.shelx import ShelxExtinction
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
 
-    assert ShelxExtinction.type_info.tag == 'shelx'
-    assert ShelxExtinction.type_info.description != ''
+    assert BeckerCoppensExtinction.type_info.tag == 'becker-coppens'
+    assert BeckerCoppensExtinction.type_info.description != ''
 
 
 def test_extinction_factory_registration():
@@ -55,17 +92,19 @@ def test_extinction_factory_registration():
         ExtinctionFactory,
     )
 
-    assert 'shelx' in ExtinctionFactory.supported_tags()
+    assert 'becker-coppens' in ExtinctionFactory.supported_tags()
 
 
 def test_extinction_factory_create():
     from easydiffraction.datablocks.experiment.categories.extinction.factory import (
         ExtinctionFactory,
     )
-    from easydiffraction.datablocks.experiment.categories.extinction.shelx import ShelxExtinction
+    from easydiffraction.datablocks.experiment.categories.extinction.becker_coppens import (
+        BeckerCoppensExtinction,
+    )
 
-    ext = ExtinctionFactory.create('shelx')
-    assert isinstance(ext, ShelxExtinction)
+    ext = ExtinctionFactory.create('becker-coppens')
+    assert isinstance(ext, BeckerCoppensExtinction)
 
 
 def test_extinction_factory_default_tag():
@@ -73,4 +112,4 @@ def test_extinction_factory_default_tag():
         ExtinctionFactory,
     )
 
-    assert ExtinctionFactory.default_tag() == 'shelx'
+    assert ExtinctionFactory.default_tag() == 'becker-coppens'

--- a/tmp/unsorted/show_w505.py
+++ b/tmp/unsorted/show_w505.py
@@ -3,7 +3,7 @@ files_lines = [
     ('src/easydiffraction/datablocks/experiment/categories/data/bragg_sc.py', [29,298,422]),
     ('src/easydiffraction/datablocks/experiment/categories/data/total_pd.py', [207]),
     ('src/easydiffraction/datablocks/experiment/categories/experiment_type/default.py', [30]),
-    ('src/easydiffraction/datablocks/experiment/categories/extinction/shelx.py', [20]),
+    ('src/easydiffraction/datablocks/experiment/categories/extinction/becker_coppens.py', [20]),
     ('src/easydiffraction/datablocks/experiment/item/base.py', [71,604]),
     ('src/easydiffraction/datablocks/experiment/item/factory.py', [78]),
     ('src/easydiffraction/datablocks/structure/item/base.py', [248]),


### PR DESCRIPTION
The extinction correction was incorrectly labelled as Shelx-style. CrysPy implements analytical Becker-Coppens spherical extinction (primary x secondary), not the empirical Shelx model.

- Rename `ShelxExtinction` -> `BeckerCoppensExtinction` (tag `becker-coppens`)
- Add `model` StringDescriptor to switch between `'gauss'` and `'lorentz'` mosaicity distributions
