### PR TITLE
Improve Plotly powder plots with background and clearer hover details

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,8 +7,8 @@
 - Domain axes: `sample_form` (powder, single crystal), `beam_mode`
   (time-of-flight, constant wavelength), `radiation_probe` (neutron,
   x-ray), `scattering_type` (bragg, total).
-- Calculation backends: `cryspy` and `crysfml` (Bragg), `pdffit2`
-  (total scattering).
+- Calculation backends: `cryspy` and `crysfml` (Bragg), `pdffit2` (total
+  scattering).
 - CIF maps to `DatablockItem`/`DatablockCollection` and
   `CategoryItem`/`CategoryCollection` (loops). Follow CIF naming;
   deviate only for a clearly better API.
@@ -35,9 +35,9 @@
 - No `**kwargs` — use explicit keyword arguments.
 - No string-based dispatch (e.g. `getattr(self, f'_{name}')`); write
   named methods (`_set_sample_form`, `_set_beam_mode`).
-- Public attrs are either editable (getter+setter property) or
-  read-only (getter only). For internal mutation of read-only props,
-  use a private `_set_<name>` method, not a public setter.
+- Public attrs are either editable (getter+setter property) or read-only
+  (getter only). For internal mutation of read-only props, use a private
+  `_set_<name>` method, not a public setter.
 - Lint complexity thresholds in `pyproject.toml` (`max-args`,
   `max-branches`, `max-statements`, `max-locals`, `max-nested-blocks`,
   …) are guardrails. A violation means refactor (extract helpers,
@@ -54,25 +54,25 @@
   monkey-patching or runtime class mutation.
 - No `__all__`; control public API via explicit `__init__.py` imports.
   No redundant `import X as X` aliases.
-- Concrete classes use `@Factory.register`. Each package's
-  `__init__.py` must explicitly import every concrete class to trigger
-  registration — always update it when adding a class.
-- Switchable categories (factory-swappable at runtime) follow this
-  fixed API on the owner (experiment / structure / analysis):
-  `<category>` (read-only), `<category>_type` (getter+setter),
-  `show_supported_<category>_types()`,
-  `show_current_<category>_type()`. The owner owns the type setter and
-  show methods; show methods delegate to `Factory.show_supported(...)`.
-  Required even if only one implementation exists.
-- Categories are flat siblings within their owner. Never nest a
-  category as a child of another category of a different type;
-  cross-reference via IDs instead.
+- Concrete classes use `@Factory.register`. Each package's `__init__.py`
+  must explicitly import every concrete class to trigger registration —
+  always update it when adding a class.
+- Switchable categories (factory-swappable at runtime) follow this fixed
+  API on the owner (experiment / structure / analysis): `<category>`
+  (read-only), `<category>_type` (getter+setter),
+  `show_supported_<category>_types()`, `show_current_<category>_type()`.
+  The owner owns the type setter and show methods; show methods delegate
+  to `Factory.show_supported(...)`. Required even if only one
+  implementation exists.
+- Categories are flat siblings within their owner. Never nest a category
+  as a child of another category of a different type; cross-reference
+  via IDs instead.
 - Every finite, closed set of values (factory tags, axes, enumerated
   descriptors) is a `(str, Enum)`; compare against members, not raw
   strings.
 - Keep `core/` free of domain logic (base classes and utilities only).
-- Don't introduce abstractions before a concrete second use case.
-  Don't add dependencies without asking.
+- Don't introduce abstractions before a concrete second use case. Don't
+  add dependencies without asking.
 
 ## Testing
 
@@ -83,7 +83,8 @@
   `tests/unit/easydiffraction/<pkg>/test_<mod>.py`. Verify with
   `pixi run test-structure-check`. Supplementary tests:
   `test_<mod>_coverage.py`. Category packages with only
-  `default.py`/`factory.py` may use one parent-level `test_<package>.py`.
+  `default.py`/`factory.py` may use one parent-level
+  `test_<package>.py`.
 - Tests expecting `log.error()` to raise must `monkeypatch` Logger to
   RAISE mode (another test may have leaked WARN mode).
 - `@typechecked` setters raise `typeguard.TypeCheckError`, not
@@ -103,16 +104,15 @@
   switchable-category wiring, datablocks, CIF serialisation), read
   `docs/architecture/architecture.md` and follow documented patterns.
   Localised bug fixes or test updates need only this file.
-- Project is in beta: no legacy shims, no deprecation warnings —
-  update tests and tutorials to the current API.
+- Project is in beta: no legacy shims, no deprecation warnings — update
+  tests and tutorials to the current API.
 - Minimal diffs; don't reformat working code. Fix only what's asked;
   flag adjacent issues as comments. Don't add features or refactor
   unless asked. Don't remove TODOs or comments unless the change fully
   resolves them.
 - Never remove or replace existing functionality without explicit
   confirmation — highlight every removal and wait for approval.
-- When renaming, grep the entire project (code, tests, tutorials,
-  docs).
+- When renaming, grep the entire project (code, tests, tutorials, docs).
 - Each change is atomic and single-commit-sized: make one change,
   suggest the commit message, then stop and wait for confirmation.
 - When in doubt, ask.
@@ -125,24 +125,24 @@
   - Add ChebyshevPolynomialBackground class
   - Implement background_type setter on Experiment
   - Standardize switchable-category naming convention
-- Stage only the files modified for the step, using explicit paths
-  where practical. Do not include data, project, CIF, or other
-  generated artifacts produced by integration/script/notebook tests
-  unless the user explicitly asked to update them.
+- Stage only the files modified for the step, using explicit paths where
+  practical. Do not include data, project, CIF, or other generated
+  artifacts produced by integration/script/notebook tests unless the
+  user explicitly asked to update them.
 - Before each commit, inspect the worktree and avoid staging unrelated
-  user changes. If unrelated dirty files exist, leave them untouched
-  and mention them only when relevant.
+  user changes. If unrelated dirty files exist, leave them untouched and
+  mention them only when relevant.
 
 ## Workflow
 
 Non-trivial changes use a two-phase workflow:
 
 - **Phase 1 — Implementation.** Code, docs, and architecture updates
-  only. Do not create or run tests unless the user explicitly asks.
-  When done, present for review and iterate until approved.
-- **Phase 2 — Verification.** Add/update tests, then run
-  `pixi run fix`, `pixi run check`, `pixi run unit-tests`,
-  `pixi run integration-tests`, `pixi run script-tests`.
+  only. Do not create or run tests unless the user explicitly asks. When
+  done, present for review and iterate until approved.
+- **Phase 2 — Verification.** Add/update tests, then run `pixi run fix`,
+  `pixi run check`, `pixi run unit-tests`, `pixi run integration-tests`,
+  `pixi run script-tests`.
 
 Notes:
 
@@ -158,8 +158,8 @@ Notes:
 
 When asked to create a plan:
 
-- First gather enough repository context to make the plan concrete.
-  Ask all ambiguous or unclear questions in one concise batch; record
+- First gather enough repository context to make the plan concrete. Ask
+  all ambiguous or unclear questions in one concise batch; record
   unresolved questions in the plan if the user wants it saved before
   answering them.
 - Save plans as `docs/dev/plan_<feature-name>.md` (lowercase,
@@ -171,9 +171,9 @@ When asked to create a plan:
 - Apply the two-phase workflow (Phase 1 implementation, Phase 2
   verification) to non-trivial plans. Stop after Phase 1 and ask the
   user to review before starting Phase 2.
-- Every completed implementation step ends with a local commit
-  following the rules in **Commits**. Keep commits atomic,
-  single-purpose, and aligned with plan steps.
+- Every completed implementation step ends with a local commit following
+  the rules in **Commits**. Keep commits atomic, single-purpose, and
+  aligned with plan steps.
 - The plan should be easy to maintain while working: include concrete
   files likely to change, decisions already made, open questions,
   verification commands for Phase 2, and a short suggested commit

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,7 +153,8 @@
   update those artifacts.
 - Keep commits atomic, single-purpose, and aligned with plan steps. Use
   imperative commit messages, no type prefix, and keep the subject line
-  at or below 72 characters.
+  at or below 72 characters. Do not add "Co-authored-by: Copilot" to the
+  commit message.
 - Before each commit, inspect the worktree and avoid staging unrelated
   user changes. If unrelated dirty files exist, leave them untouched and
   mention them only when relevant.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,18 +4,18 @@
 
 - Python library for crystallographic diffraction analysis (refining
   structural models against experimental data).
-- Axes: `sample_form` (powder, single crystal), `beam_mode` (time-of-
-  flight, constant wavelength), `radiation_probe` (neutron, x-ray),
-  `scattering_type` (bragg, total).
-- Calculation backends: `cryspy` and `crysfml` (Bragg), `pdffit2` (total
-  scattering).
-- Follow CIF naming conventions; deviate only for clearly better API.
-- CIF concepts map to: `DatablockItem` / `DatablockCollection` and
-  `CategoryItem` / `CategoryCollection` (loops).
+- Domain axes: `sample_form` (powder, single crystal), `beam_mode`
+  (time-of-flight, constant wavelength), `radiation_probe` (neutron,
+  x-ray), `scattering_type` (bragg, total).
+- Calculation backends: `cryspy` and `crysfml` (Bragg), `pdffit2`
+  (total scattering).
+- CIF maps to `DatablockItem`/`DatablockCollection` and
+  `CategoryItem`/`CategoryCollection` (loops). Follow CIF naming;
+  deviate only for a clearly better API.
 - Metadata via frozen dataclasses: `TypeInfo`, `Compatibility`,
   `CalculatorSupport`.
-- Audience: scientists, often non-programmers. Prioritize
-  discoverability, clear errors, safe defaults over developer
+- Audience is scientists, often non-programmers: prioritize
+  discoverability, clear errors, and safe defaults over developer
   ergonomics.
 - Critical-software rigor: every code path tested, edge cases handled
   explicitly, no silent failures.
@@ -24,62 +24,55 @@
 
 - snake_case (functions/vars), PascalCase (classes), UPPER_SNAKE_CASE
   (constants).
-- `from __future__ import annotations` in every module.
-- Type-annotate all public signatures.
-- Numpy-style docstrings on all public classes/methods, with Parameters
-  / Returns / Raises where applicable. Summary is one line ≤72 chars
+- `from __future__ import annotations` in every module. Type-annotate
+  all public signatures.
+- Numpy-style docstrings on all public classes/methods (Parameters /
+  Returns / Raises where applicable). Summary is one line ≤72 chars
   (`max-doc-length`); shorten wording rather than wrap.
-- Flat over nested, explicit over clever. No defensive checks for
-  unlikely edge cases. Composition over deep inheritance.
+- Flat over nested, explicit over clever, composition over deep
+  inheritance. No defensive checks for unlikely edge cases.
 - One class per file when substantial; group small related classes.
 - No `**kwargs` — use explicit keyword arguments.
 - No string-based dispatch (e.g. `getattr(self, f'_{name}')`); write
-  explicit named methods (`_set_sample_form`, `_set_beam_mode`).
-- Public attrs are either editable (getter+setter property) or read-only
-  (getter only). For internal mutation of read-only props, add a private
-  `_set_<name>` method, not a public setter.
+  named methods (`_set_sample_form`, `_set_beam_mode`).
+- Public attrs are either editable (getter+setter property) or
+  read-only (getter only). For internal mutation of read-only props,
+  use a private `_set_<name>` method, not a public setter.
 - Lint complexity thresholds in `pyproject.toml` (`max-args`,
   `max-branches`, `max-statements`, `max-locals`, `max-nested-blocks`,
   …) are guardrails. A violation means refactor (extract helpers,
-  parameter objects, flatten). Do not raise thresholds, add `# noqa`, or
-  otherwise silence them. For complex refactors touching many lines or
-  public API, propose a plan and wait for approval.
+  parameter objects, flatten) — do not raise thresholds, add `# noqa`,
+  or otherwise silence them. For complex refactors touching many lines
+  or public API, propose a plan and wait for approval.
 
 ## Architecture
 
 - Eager top-of-module imports by default. Lazy imports only to break
-  circular deps or keep `core/` free of heavy imports on rarely-called
-  paths (e.g. `help()`).
-- No `pkgutil` / `importlib` auto-discovery, no background threads, no
+  circular deps or to keep `core/` free of heavy imports on rarely-
+  called paths (e.g. `help()`).
+- No `pkgutil`/`importlib` auto-discovery, no background threads, no
   monkey-patching or runtime class mutation.
 - No `__all__`; control public API via explicit `__init__.py` imports.
-- No redundant `import X as X` aliases — use plain
-  `from module import X`.
-- Concrete classes use `@Factory.register`. Each package's `__init__.py`
-  must explicitly import every concrete class to trigger registration.
-  Always add new concrete classes to the corresponding `__init__.py`.
-- Switchable categories (factory-swappable at runtime) follow this fixed
-  API on the owner (experiment / structure / analysis): `<category>`
-  (read-only), `<category>_type` (getter+setter),
-  `show_supported_<category>_types()`, `show_current_<category>_type()`.
-  The owner owns the type setter and show methods; show methods delegate
-  to `Factory.show_supported(...)`. Required even if only one
-  implementation exists.
-- Categories are flat siblings within their owner. Never nest a category
-  as a child of another category of a different type; cross-reference
-  via IDs instead.
+  No redundant `import X as X` aliases.
+- Concrete classes use `@Factory.register`. Each package's
+  `__init__.py` must explicitly import every concrete class to trigger
+  registration — always update it when adding a class.
+- Switchable categories (factory-swappable at runtime) follow this
+  fixed API on the owner (experiment / structure / analysis):
+  `<category>` (read-only), `<category>_type` (getter+setter),
+  `show_supported_<category>_types()`,
+  `show_current_<category>_type()`. The owner owns the type setter and
+  show methods; show methods delegate to `Factory.show_supported(...)`.
+  Required even if only one implementation exists.
+- Categories are flat siblings within their owner. Never nest a
+  category as a child of another category of a different type;
+  cross-reference via IDs instead.
 - Every finite, closed set of values (factory tags, axes, enumerated
-  descriptors) uses a `(str, Enum)` class; compare against members, not
-  raw strings.
+  descriptors) is a `(str, Enum)`; compare against members, not raw
+  strings.
 - Keep `core/` free of domain logic (base classes and utilities only).
 - Don't introduce abstractions before a concrete second use case.
-- Don't add dependencies without asking.
-
-## Tutorials
-
-- Notebooks in `docs/docs/tutorials/*.ipynb` are generated artifacts.
-  Edit only the corresponding `*.py`, then run
-  `pixi run notebook-prepare`.
+  Don't add dependencies without asking.
 
 ## Testing
 
@@ -88,10 +81,9 @@
 - Unit tests mirror the source tree:
   `src/easydiffraction/<pkg>/<mod>.py` →
   `tests/unit/easydiffraction/<pkg>/test_<mod>.py`. Verify with
-  `pixi run test-structure-check`.
-- Category packages with only `default.py`/`factory.py` may use one
-  parent-level `test_<package>.py`.
-- Supplementary tests: `test_<mod>_coverage.py`.
+  `pixi run test-structure-check`. Supplementary tests:
+  `test_<mod>_coverage.py`. Category packages with only
+  `default.py`/`factory.py` may use one parent-level `test_<package>.py`.
 - Tests expecting `log.error()` to raise must `monkeypatch` Logger to
   RAISE mode (another test may have leaked WARN mode).
 - `@typechecked` setters raise `typeguard.TypeCheckError`, not
@@ -99,88 +91,90 @@
 - No test-ordering dependence, no network, no sleeping, no real
   calculation engines in unit tests.
 
-## Changes
+## Tutorials
+
+- Notebooks in `docs/docs/tutorials/*.ipynb` are generated artifacts.
+  Edit only the corresponding `*.py`, then run
+  `pixi run notebook-prepare`.
+
+## Change Discipline
 
 - Before any structural/design change (new categories, factories,
   switchable-category wiring, datablocks, CIF serialisation), read
   `docs/architecture/architecture.md` and follow documented patterns.
   Localised bug fixes or test updates need only this file.
-- Project is in beta: no legacy shims, no deprecation warnings — update
-  tests and tutorials to current API.
-- Minimal diffs; don't reformat working code.
+- Project is in beta: no legacy shims, no deprecation warnings —
+  update tests and tutorials to the current API.
+- Minimal diffs; don't reformat working code. Fix only what's asked;
+  flag adjacent issues as comments. Don't add features or refactor
+  unless asked. Don't remove TODOs or comments unless the change fully
+  resolves them.
 - Never remove or replace existing functionality without explicit
-  confirmation. Highlight every removal and wait for approval.
-- Fix only what's asked; flag adjacent issues as comments.
-- Don't add features or refactor unless asked. Don't remove TODOs or
-  comments unless the change fully resolves them.
-- When renaming, grep the entire project (code, tests, tutorials, docs).
-- Each change is atomic, single-commit-sized. Make one change, suggest
-  the commit message, then stop and wait for confirmation.
+  confirmation — highlight every removal and wait for approval.
+- When renaming, grep the entire project (code, tests, tutorials,
+  docs).
+- Each change is atomic and single-commit-sized: make one change,
+  suggest the commit message, then stop and wait for confirmation.
 - When in doubt, ask.
+
+## Commits
+
+- Suggest a commit message after each change: code block, ≤72 chars,
+  imperative mood, no type prefix, no `Co-authored-by: Copilot`.
+  Examples:
+  - Add ChebyshevPolynomialBackground class
+  - Implement background_type setter on Experiment
+  - Standardize switchable-category naming convention
+- Stage only the files modified for the step, using explicit paths
+  where practical. Do not include data, project, CIF, or other
+  generated artifacts produced by integration/script/notebook tests
+  unless the user explicitly asked to update them.
+- Before each commit, inspect the worktree and avoid staging unrelated
+  user changes. If unrelated dirty files exist, leave them untouched
+  and mention them only when relevant.
 
 ## Workflow
 
-### Planning Workflow
+Non-trivial changes use a two-phase workflow:
 
-- When asked to create a plan, first gather enough repository context to
-  make the plan concrete. Ask all ambiguous, potentially ambiguous, or
-  unclear questions in one concise batch, and record unresolved
-  questions in the plan if the user wants the plan saved before
-  answering them.
-- Save plans as Markdown files in `docs/dev` with the filename pattern
-  `plan_<feature-name>.md`. The `<feature-name>` part uses lowercase
-  words separated by dashes, for example
-  `docs/dev/plan_background-refactor.md`.
-- Use the same `<feature-name>` to create the implementation branch,
-  normally `feature/<feature-name>`. Do not push the branch unless the
-  user explicitly asks.
-- Each plan must include a status checklist with `[ ]` items. Mark each
-  item as `[x]` as it is completed during implementation.
-- Plans for non-trivial work must separate the work into two phases:
-  - **Phase 1 — Implementation:** the agent works independently through
-    all implementation steps, updating the plan checklist as it goes. Do
-    not create tests or run tests in this phase unless the user
-    explicitly asks. When Phase 1 is complete, stop and ask the user to
-    review the implementation.
-  - **Phase 2 — Verification:** after user approval, add/update tests,
-    run formatting, linting, unit tests, integration tests, and script
-    or notebook checks requested by the plan.
-- Every completed implementation step must end with a local commit.
-  Stage only the files modified for that step, using explicit paths
-  where practical. Do not include data files, project files, CIF files,
-  or other generated artifacts created by integration tests, script
-  tests, or notebook execution unless the user explicitly asked to
-  update those artifacts.
-- Keep commits atomic, single-purpose, and aligned with plan steps. Use
-  imperative commit messages, no type prefix, and keep the subject line
-  at or below 72 characters. Do not add "Co-authored-by: Copilot" to the
-  commit message.
-- Before each commit, inspect the worktree and avoid staging unrelated
-  user changes. If unrelated dirty files exist, leave them untouched and
-  mention them only when relevant.
-- The plan should be easy to maintain while working: include concrete
-  files likely to change, decisions already made, open questions,
-  verification commands for Phase 2, and a short suggested commit
-  message or branch name when useful.
+- **Phase 1 — Implementation.** Code, docs, and architecture updates
+  only. Do not create or run tests unless the user explicitly asks.
+  When done, present for review and iterate until approved.
+- **Phase 2 — Verification.** Add/update tests, then run
+  `pixi run fix`, `pixi run check`, `pixi run unit-tests`,
+  `pixi run integration-tests`, `pixi run script-tests`.
 
-### General Workflow
+Notes:
 
-- Two-phase workflow for non-trivial changes:
-  - **Phase 1 — Implementation:** code, docs, architecture updates. Do
-    not create new tests or run existing tests. Present for review and
-    iterate until approved.
-  - **Phase 2 — Verification:** add/update tests, then run
-    `pixi run fix`, `pixi run check`, `pixi run unit-tests`,
-    `pixi run integration-tests`, `pixi run script-tests`.
+- `pixi run fix` regenerates `docs/architecture/package-structure-*.md`
+  automatically — never edit those by hand. Don't review auto-fixes;
+  accept and move on. Then `pixi run check` until clean.
 - Open issues / design questions / planned improvements live in
   `docs/architecture/issues_open.md` (priority-ordered). On resolution,
   move to `docs/architecture/issues_closed.md` and update
   `architecture.md` if affected.
-- `pixi run fix` regenerates `docs/architecture/package-structure-*.md`
-  automatically — never edit those by hand. Don't review auto-fixes;
-  accept and move on. Then `pixi run check` until clean.
-- Suggest a commit message (code block, ≤72 chars, imperative mood, no
-  type prefix) after each change. E.g.:
-  - Add ChebyshevPolynomialBackground class
-  - Implement background_type setter on Experiment
-  - Standardize switchable-category naming convention
+
+### Planning
+
+When asked to create a plan:
+
+- First gather enough repository context to make the plan concrete.
+  Ask all ambiguous or unclear questions in one concise batch; record
+  unresolved questions in the plan if the user wants it saved before
+  answering them.
+- Save plans as `docs/dev/plan_<feature-name>.md` (lowercase,
+  dash-separated, e.g. `plan_background-refactor.md`). Use the same
+  `<feature-name>` for the implementation branch
+  (`feature/<feature-name>`). Do not push the branch unless asked.
+- Include a status checklist with `[ ]` items; mark `[x]` as completed
+  during implementation.
+- Apply the two-phase workflow (Phase 1 implementation, Phase 2
+  verification) to non-trivial plans. Stop after Phase 1 and ask the
+  user to review before starting Phase 2.
+- Every completed implementation step ends with a local commit
+  following the rules in **Commits**. Keep commits atomic,
+  single-purpose, and aligned with plan steps.
+- The plan should be easy to maintain while working: include concrete
+  files likely to change, decisions already made, open questions,
+  verification commands for Phase 2, and a short suggested commit
+  message or branch name when useful.

--- a/docs/architecture/package-structure-full.md
+++ b/docs/architecture/package-structure-full.md
@@ -365,6 +365,7 @@
 │   ├── 📄 plotting.py
 │   │   ├── 🏷️ class PlotterEngineEnum
 │   │   ├── 🏷️ class _MeasVsCalcPlotOptions
+│   │   ├── 🏷️ class _PowderMeasVsCalcSeries
 │   │   ├── 🏷️ class Plotter
 │   │   └── 🏷️ class PlotterFactory
 │   ├── 📄 tables.py

--- a/src/easydiffraction/display/plotters/base.py
+++ b/src/easydiffraction/display/plotters/base.py
@@ -44,9 +44,9 @@ class PowderMeasVsCalcSpec:
     """
     Specification for one composite powder plot.
 
-    The plotting facade assembles the measured, background,
-    calculated, residual, and Bragg-tick data into this
-    display-specific object before delegating to a backend.
+    The plotting facade assembles the measured, background, calculated,
+    residual, and Bragg-tick data into this display-specific object
+    before delegating to a backend.
     """
 
     x: np.ndarray

--- a/src/easydiffraction/display/plotters/base.py
+++ b/src/easydiffraction/display/plotters/base.py
@@ -44,9 +44,9 @@ class PowderMeasVsCalcSpec:
     """
     Specification for one composite powder plot.
 
-    The plotting facade assembles the measured, calculated, residual,
-    and Bragg-tick data into this display-specific object before
-    delegating to a backend.
+    The plotting facade assembles the measured, background,
+    calculated, residual, and Bragg-tick data into this
+    display-specific object before delegating to a backend.
     """
 
     x: np.ndarray
@@ -59,6 +59,7 @@ class PowderMeasVsCalcSpec:
     residual_height_fraction: float
     bragg_peaks_height_fraction: float
     height: int | None = None
+    y_bkg: np.ndarray | None = None
 
 
 class XAxisType(StrEnum):
@@ -183,6 +184,10 @@ SERIES_CONFIG = {
     'calc': {
         'mode': 'lines',
         'name': 'Total calculated (Icalc)',
+    },
+    'bkg': {
+        'mode': 'lines',
+        'name': 'Background (Ibkg)',
     },
     'meas': {
         'mode': 'lines+markers',

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -957,9 +957,9 @@ class PlotlyPlotter(PlotterBase):
 
         main_traces = (
             (
+                ('meas', plot_spec.y_meas),
                 ('bkg', plot_spec.y_bkg),
                 ('calc', plot_spec.y_calc),
-                ('meas', plot_spec.y_meas),
             )
             if plot_spec.y_bkg is not None
             else (

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -717,28 +717,32 @@ class PlotlyPlotter(PlotterBase):
 
     @staticmethod
     def _composite_plot_area_height(full_height: float) -> float:
-        """Return the drawable plot area height after vertical margins."""
+        """
+        Return the drawable plot area height after vertical margins.
+        """
         return max(full_height - COMPOSITE_MARGIN_TOP - COMPOSITE_MARGIN_BOTTOM, 1.0)
 
     @staticmethod
     def _subplot_available_height_fraction(row_count: int) -> float:
-        """Return the fraction of plot height available for subplot rows."""
+        """
+        Return the fraction of plot height available for subplot rows.
+        """
         return 1.0 - COMPOSITE_VERTICAL_SPACING * max(row_count - 1, 0)
 
     @staticmethod
     def _bragg_tick_symbol_height_pixels() -> float:
         """Return rendered pixel height for one Bragg tick marker."""
         return (
-            BRAGG_TICK_MARKER_SIZE * BRAGG_TICK_SYMBOL_HEIGHT_SCALE
-            + BRAGG_TICK_MARKER_LINE_WIDTH
+            BRAGG_TICK_MARKER_SIZE * BRAGG_TICK_SYMBOL_HEIGHT_SCALE + BRAGG_TICK_MARKER_LINE_WIDTH
         )
 
     @staticmethod
     def _bragg_row_height_pixels(plot_spec: PowderMeasVsCalcSpec) -> float:
-        """Return the exact Bragg-row pixel height for the current phases."""
+        """
+        Return the exact Bragg-row pixel height for the current phases.
+        """
         return float(
-            len(plot_spec.bragg_tick_sets)
-            * PlotlyPlotter._bragg_tick_symbol_height_pixels()
+            len(plot_spec.bragg_tick_sets) * PlotlyPlotter._bragg_tick_symbol_height_pixels()
         )
 
     @classmethod
@@ -753,7 +757,9 @@ class PlotlyPlotter(PlotterBase):
         baseline_height = cls._base_composite_height_pixels(plot_spec)
         plot_area_height = cls._composite_plot_area_height(baseline_height)
         available_row_pixels = plot_area_height * cls._subplot_available_height_fraction(row_count)
-        baseline_bragg_pixels = float(cls._bragg_tick_symbol_height_pixels() if has_bragg_ticks else 0)
+        baseline_bragg_pixels = float(
+            cls._bragg_tick_symbol_height_pixels() if has_bragg_ticks else 0
+        )
         non_bragg_pixels = max(available_row_pixels - baseline_bragg_pixels, 1.0)
 
         if not has_residual:
@@ -801,21 +807,26 @@ class PlotlyPlotter(PlotterBase):
         plot_spec: PowderMeasVsCalcSpec,
         layout: PowderCompositeRows,
     ) -> float:
-        """Return figure height with Bragg growth from a single-phase baseline."""
+        """
+        Return figure height with Bragg growth from a single-phase
+        baseline.
+        """
         base_pixels = cls._base_composite_height_pixels(plot_spec)
         phase_count = len(plot_spec.bragg_tick_sets)
         if phase_count <= 1:
             return base_pixels
 
-        added_bragg_pixels = float(
-            (phase_count - 1) * cls._bragg_tick_symbol_height_pixels()
+        added_bragg_pixels = float((phase_count - 1) * cls._bragg_tick_symbol_height_pixels())
+        growth_pixels = added_bragg_pixels / cls._subplot_available_height_fraction(
+            layout.row_count
         )
-        growth_pixels = added_bragg_pixels / cls._subplot_available_height_fraction(layout.row_count)
         return base_pixels + growth_pixels
 
     @classmethod
     def _get_main_intensity_range(cls, plot_spec: PowderMeasVsCalcSpec) -> tuple[float, float]:
-        """Return an explicit y-range for the main powder intensity row."""
+        """
+        Return an explicit y-range for the main powder intensity row.
+        """
         y_meas = np.asarray(plot_spec.y_meas)
         y_calc = np.asarray(plot_spec.y_calc)
         if min(y_meas.size, y_calc.size) == 0:
@@ -823,7 +834,7 @@ class PlotlyPlotter(PlotterBase):
 
         main_y_min = float(min(np.min(y_meas), np.min(y_calc)))
         main_y_max = float(max(np.max(y_meas), np.max(y_calc)))
-        lower_limit = 0.0 if main_y_min >= 0.0 else main_y_min
+        lower_limit = min(0.0, main_y_min)
         if main_y_max <= lower_limit:
             return lower_limit - 1.0, lower_limit + 1.0
         return lower_limit, main_y_max

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -750,6 +750,7 @@ class PlotlyPlotter(PlotterBase):
         cls,
         plot_spec: PowderMeasVsCalcSpec,
         row_count: int,
+        *,
         has_bragg_ticks: bool,
         has_residual: bool,
     ) -> tuple[float, float | None]:
@@ -807,10 +808,7 @@ class PlotlyPlotter(PlotterBase):
         plot_spec: PowderMeasVsCalcSpec,
         layout: PowderCompositeRows,
     ) -> float:
-        """
-        Return figure height with Bragg growth from a single-phase
-        baseline.
-        """
+        """Return figure height for Bragg row growth."""
         base_pixels = cls._base_composite_height_pixels(plot_spec)
         phase_count = len(plot_spec.bragg_tick_sets)
         if phase_count <= 1:

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -937,6 +937,13 @@ class PlotlyPlotter(PlotterBase):
 
         return cls._nice_axis_limit(float(np.max(np.abs(y_resid))))
 
+    @staticmethod
+    def _composite_x_range(x_values: np.ndarray) -> tuple[float | None, float | None]:
+        """Return the explicit x-range for the composite powder plot."""
+        if x_values.size == 0:
+            return None, None
+        return float(np.min(x_values)), float(np.max(x_values))
+
     def plot_powder_meas_vs_calc(
         self,
         plot_spec: PowderMeasVsCalcSpec,
@@ -949,10 +956,7 @@ class PlotlyPlotter(PlotterBase):
         residual row is added only when residual data is requested.
         """
         layout = self._get_powder_composite_rows(plot_spec)
-        x_values = np.asarray(plot_spec.x)
-        has_x_values = x_values.size > 0
-        x_min = float(np.min(x_values)) if has_x_values else None
-        x_max = float(np.max(x_values)) if has_x_values else None
+        x_min, x_max = self._composite_x_range(np.asarray(plot_spec.x))
         main_y_min, main_y_max = self._get_main_intensity_range(plot_spec)
         residual_limit = None
         hover_data = self._powder_meas_vs_calc_hover_data(plot_spec)
@@ -1044,7 +1048,7 @@ class PlotlyPlotter(PlotterBase):
                 'tickformat': ',.6~g',
                 'separatethousands': True,
             }
-            if has_x_values:
+            if x_min is not None and x_max is not None:
                 x_axis_kwargs['range'] = [x_min, x_max]
             fig.update_xaxes(row=row_idx, col=1, **x_axis_kwargs)
             fig.update_yaxes(

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -361,6 +361,9 @@ class PlotlyPlotter(PlotterBase):
         x: object,
         y: object,
         label: str,
+        *,
+        customdata: object | None = None,
+        hovertemplate: str | None = None,
     ) -> object:
         """
         Create a Plotly trace for powder diffraction data.
@@ -373,6 +376,11 @@ class PlotlyPlotter(PlotterBase):
             1D array- like of y-axis values.
         label : str
             Series identifier (``'meas'``, ``'calc'``, or ``'resid'``).
+        customdata : object | None, default=None
+            Optional per-point payload used by the hover template.
+        hovertemplate : str | None, default=None
+            Optional hover template overriding the default per-trace
+            one.
 
         Returns
         -------
@@ -390,7 +398,39 @@ class PlotlyPlotter(PlotterBase):
             line=line,
             mode=mode,
             name=name,
-            hovertemplate=f'{name}<br>x: %{{x}}<br>y: %{{y}}<extra></extra>',
+            customdata=customdata,
+            hovertemplate=(
+                hovertemplate
+                if hovertemplate is not None
+                else f'{name}<br>x: %{{x}}<br>y: %{{y}}<extra></extra>'
+            ),
+        )
+
+    @staticmethod
+    def _powder_meas_vs_calc_hover_data(plot_spec: PowderMeasVsCalcSpec) -> np.ndarray:
+        """Return shared hover values for composite powder traces."""
+        residual_values = (
+            np.asarray(plot_spec.y_resid)
+            if plot_spec.y_resid is not None
+            else np.asarray(plot_spec.y_meas) - np.asarray(plot_spec.y_calc)
+        )
+        return np.column_stack((
+            np.asarray(plot_spec.y_meas),
+            np.asarray(plot_spec.y_calc),
+            residual_values,
+        ))
+
+    @staticmethod
+    def _powder_meas_vs_calc_hover_template() -> str:
+        """
+        Return a shared hover template for composite powder traces.
+        """
+        return (
+            'x: %{x:,.2f}<br>'
+            'Imeas: %{customdata[0]:,.2f}<br>'
+            'Icalc: %{customdata[1]:,.2f}<br>'
+            'Imeas - Icalc: %{customdata[2]:,.2f}'
+            '<extra></extra>'
         )
 
     @staticmethod
@@ -649,11 +689,13 @@ class PlotlyPlotter(PlotterBase):
         y = np.full(tick_set.x.shape, row_y, dtype=float)
         hover_text = []
         for idx, x_value in enumerate(tick_set.x):
+            index_h = int(tick_set.h[idx])
+            index_k = int(tick_set.k[idx])
+            index_l = int(tick_set.ell[idx])
             hover_text.append(
-                f'Bragg peaks: {tick_set.phase_id}<br>'
-                f'Miller indices: ({int(tick_set.h[idx])} {int(tick_set.k[idx])} '
-                f'{int(tick_set.ell[idx])})<br>'
-                f'x: {float(x_value):.6g}<br>'
+                f'{tick_set.phase_id}<br>'
+                f'x: {float(x_value):,.2f}<br>'
+                f'Miller indices: ({index_h} {index_k} {index_l})<br>'
                 # f'F²cal:{float(tick_set.f_squared_calc[idx]):.6g}<br>'
                 # f'Fcalc:{float(tick_set.f_calc[idx]):.6g}'
                 '<extra></extra>'
@@ -875,6 +917,8 @@ class PlotlyPlotter(PlotterBase):
         x_max = float(np.max(x_values)) if has_x_values else None
         main_y_min, main_y_max = self._get_main_intensity_range(plot_spec)
         residual_limit = None
+        hover_data = self._powder_meas_vs_calc_hover_data(plot_spec)
+        hover_template = self._powder_meas_vs_calc_hover_template()
 
         fig = make_subplots(
             rows=layout.row_count,
@@ -884,8 +928,28 @@ class PlotlyPlotter(PlotterBase):
             row_heights=layout.row_heights,
         )
 
-        fig.add_trace(self._get_powder_trace(plot_spec.x, plot_spec.y_meas, 'meas'), row=1, col=1)
-        fig.add_trace(self._get_powder_trace(plot_spec.x, plot_spec.y_calc, 'calc'), row=1, col=1)
+        fig.add_trace(
+            self._get_powder_trace(
+                plot_spec.x,
+                plot_spec.y_meas,
+                'meas',
+                customdata=hover_data,
+                hovertemplate=hover_template,
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            self._get_powder_trace(
+                plot_spec.x,
+                plot_spec.y_calc,
+                'calc',
+                customdata=hover_data,
+                hovertemplate=hover_template,
+            ),
+            row=1,
+            col=1,
+        )
 
         if layout.bragg_row is not None:
             for idx, tick_set in enumerate(plot_spec.bragg_tick_sets):
@@ -903,7 +967,13 @@ class PlotlyPlotter(PlotterBase):
         if layout.residual_row is not None and plot_spec.y_resid is not None:
             residual_limit = self._get_residual_limit(plot_spec)
             fig.add_trace(
-                self._get_powder_trace(plot_spec.x, plot_spec.y_resid, 'resid'),
+                self._get_powder_trace(
+                    plot_spec.x,
+                    plot_spec.y_resid,
+                    'resid',
+                    customdata=hover_data,
+                    hovertemplate=hover_template,
+                ),
                 row=layout.residual_row,
                 col=1,
             )
@@ -1074,7 +1144,7 @@ class PlotlyPlotter(PlotterBase):
                 'array': sy,
                 'visible': True,
             },
-            hovertemplate='x: %{x}<br>y: %{y}<br><extra></extra>',
+            hovertemplate='x: %{x:,.2f}<br>y: %{y:,.2f}<br><extra></extra>',
         )
 
         layout = self._get_layout(

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -36,6 +36,7 @@ from easydiffraction.utils.environment import in_pycharm
 
 DEFAULT_COLORS = {
     'meas': 'rgb(31, 119, 180)',
+    'bkg': 'rgb(140, 140, 140)',
     'calc': 'rgb(214, 39, 40)',
     'resid': 'rgb(44, 160, 44)',
 }
@@ -375,7 +376,8 @@ class PlotlyPlotter(PlotterBase):
         y : object
             1D array- like of y-axis values.
         label : str
-            Series identifier (``'meas'``, ``'calc'``, or ``'resid'``).
+            Series identifier (``'meas'``, ``'bkg'``, ``'calc'``, or
+            ``'resid'``).
         customdata : object | None, default=None
             Optional per-point payload used by the hover template.
         hovertemplate : str | None, default=None
@@ -391,6 +393,12 @@ class PlotlyPlotter(PlotterBase):
         name = SERIES_CONFIG[label]['name']
         color = DEFAULT_COLORS[label]
         line = {'color': color}
+        legend_rank = {
+            'meas': 10,
+            'bkg': 20,
+            'calc': 30,
+            'resid': 40,
+        }[label]
 
         return go.Scatter(
             x=x,
@@ -398,6 +406,7 @@ class PlotlyPlotter(PlotterBase):
             line=line,
             mode=mode,
             name=name,
+            legendrank=legend_rank,
             customdata=customdata,
             hovertemplate=(
                 hovertemplate
@@ -414,22 +423,40 @@ class PlotlyPlotter(PlotterBase):
             if plot_spec.y_resid is not None
             else np.asarray(plot_spec.y_meas) - np.asarray(plot_spec.y_calc)
         )
+        if plot_spec.y_bkg is None:
+            return np.column_stack((
+                np.asarray(plot_spec.y_meas),
+                np.asarray(plot_spec.y_calc),
+                residual_values,
+            ))
+
         return np.column_stack((
             np.asarray(plot_spec.y_meas),
+            np.asarray(plot_spec.y_bkg),
             np.asarray(plot_spec.y_calc),
             residual_values,
         ))
 
     @staticmethod
-    def _powder_meas_vs_calc_hover_template() -> str:
+    def _powder_meas_vs_calc_hover_template(plot_spec: PowderMeasVsCalcSpec) -> str:
         """
         Return a shared hover template for composite powder traces.
         """
+        if plot_spec.y_bkg is None:
+            return (
+                'x: %{x:,.2f}<br>'
+                'Imeas: %{customdata[0]:,.2f}<br>'
+                'Icalc: %{customdata[1]:,.2f}<br>'
+                'Imeas - Icalc: %{customdata[2]:,.2f}'
+                '<extra></extra>'
+            )
+
         return (
             'x: %{x:,.2f}<br>'
             'Imeas: %{customdata[0]:,.2f}<br>'
-            'Icalc: %{customdata[1]:,.2f}<br>'
-            'Imeas - Icalc: %{customdata[2]:,.2f}'
+            'Ibkg: %{customdata[1]:,.2f}<br>'
+            'Icalc: %{customdata[2]:,.2f}<br>'
+            'Imeas - Icalc: %{customdata[3]:,.2f}'
             '<extra></extra>'
         )
 
@@ -918,7 +945,7 @@ class PlotlyPlotter(PlotterBase):
         main_y_min, main_y_max = self._get_main_intensity_range(plot_spec)
         residual_limit = None
         hover_data = self._powder_meas_vs_calc_hover_data(plot_spec)
-        hover_template = self._powder_meas_vs_calc_hover_template()
+        hover_template = self._powder_meas_vs_calc_hover_template(plot_spec)
 
         fig = make_subplots(
             rows=layout.row_count,
@@ -928,28 +955,30 @@ class PlotlyPlotter(PlotterBase):
             row_heights=layout.row_heights,
         )
 
-        fig.add_trace(
-            self._get_powder_trace(
-                plot_spec.x,
-                plot_spec.y_meas,
-                'meas',
-                customdata=hover_data,
-                hovertemplate=hover_template,
-            ),
-            row=1,
-            col=1,
+        main_traces = (
+            (
+                ('bkg', plot_spec.y_bkg),
+                ('calc', plot_spec.y_calc),
+                ('meas', plot_spec.y_meas),
+            )
+            if plot_spec.y_bkg is not None
+            else (
+                ('meas', plot_spec.y_meas),
+                ('calc', plot_spec.y_calc),
+            )
         )
-        fig.add_trace(
-            self._get_powder_trace(
-                plot_spec.x,
-                plot_spec.y_calc,
-                'calc',
-                customdata=hover_data,
-                hovertemplate=hover_template,
-            ),
-            row=1,
-            col=1,
-        )
+        for label, y_values in main_traces:
+            fig.add_trace(
+                self._get_powder_trace(
+                    plot_spec.x,
+                    y_values,
+                    label,
+                    customdata=hover_data,
+                    hovertemplate=hover_template,
+                ),
+                row=1,
+                col=1,
+            )
 
         if layout.bragg_row is not None:
             for idx, tick_set in enumerate(plot_spec.bragg_tick_sets):

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -41,6 +41,11 @@ DEFAULT_COLORS = {
     'resid': 'rgb(44, 160, 44)',
 }
 
+MEASURED_LINE_WIDTH = 2.0
+BACKGROUND_LINE_WIDTH = 1.0
+CALCULATED_LINE_WIDTH = 2.0
+RESIDUAL_LINE_WIDTH = 2.0
+
 BRAGG_TICK_COLORS = (
     'rgb(255, 127, 14)',
     'rgb(23, 190, 207)',
@@ -392,7 +397,13 @@ class PlotlyPlotter(PlotterBase):
         mode = SERIES_CONFIG[label]['mode']
         name = SERIES_CONFIG[label]['name']
         color = DEFAULT_COLORS[label]
-        line = {'color': color}
+        line_width = {
+            'meas': MEASURED_LINE_WIDTH,
+            'bkg': BACKGROUND_LINE_WIDTH,
+            'calc': CALCULATED_LINE_WIDTH,
+            'resid': RESIDUAL_LINE_WIDTH,
+        }[label]
+        line = {'color': color, 'width': line_width}
         legend_rank = {
             'meas': 10,
             'bkg': 20,

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -814,6 +814,21 @@ class PlotlyPlotter(PlotterBase):
         return base_pixels + growth_pixels
 
     @classmethod
+    def _get_main_intensity_range(cls, plot_spec: PowderMeasVsCalcSpec) -> tuple[float, float]:
+        """Return an explicit y-range for the main powder intensity row."""
+        y_meas = np.asarray(plot_spec.y_meas)
+        y_calc = np.asarray(plot_spec.y_calc)
+        if min(y_meas.size, y_calc.size) == 0:
+            return 0.0, 1.0
+
+        main_y_min = float(min(np.min(y_meas), np.min(y_calc)))
+        main_y_max = float(max(np.max(y_meas), np.max(y_calc)))
+        lower_limit = 0.0 if main_y_min >= 0.0 else main_y_min
+        if main_y_max <= lower_limit:
+            return lower_limit - 1.0, lower_limit + 1.0
+        return lower_limit, main_y_max
+
+    @classmethod
     def _get_residual_limit(cls, plot_spec: PowderMeasVsCalcSpec) -> float:
         """Return a symmetric residual limit matched to the main row."""
         if plot_spec.y_resid is None:
@@ -825,8 +840,7 @@ class PlotlyPlotter(PlotterBase):
         if min(y_meas.size, y_calc.size, y_resid.size) == 0:
             return 1.0
 
-        main_y_min = float(min(np.min(y_meas), np.min(y_calc)))
-        main_y_max = float(max(np.max(y_meas), np.max(y_calc)))
+        main_y_min, main_y_max = cls._get_main_intensity_range(plot_spec)
         main_y_range = max(main_y_max - main_y_min, 0.0)
         scale_matched_half_range = 0.5 * main_y_range * plot_spec.residual_height_fraction
         if scale_matched_half_range > 0.0:
@@ -850,6 +864,8 @@ class PlotlyPlotter(PlotterBase):
         has_x_values = x_values.size > 0
         x_min = float(np.min(x_values)) if has_x_values else None
         x_max = float(np.max(x_values)) if has_x_values else None
+        main_y_min, main_y_max = self._get_main_intensity_range(plot_spec)
+        residual_limit = None
 
         fig = make_subplots(
             rows=layout.row_count,
@@ -923,7 +939,12 @@ class PlotlyPlotter(PlotterBase):
             )
 
         fig.update_xaxes(showticklabels=(layout.row_count == 1), row=1, col=1)
-        fig.update_yaxes(title_text=plot_spec.axes_labels[1], row=1, col=1)
+        fig.update_yaxes(
+            title_text=plot_spec.axes_labels[1],
+            range=[main_y_min, main_y_max],
+            row=1,
+            col=1,
+        )
 
         if layout.bragg_row is not None:
             fig.update_yaxes(
@@ -949,6 +970,8 @@ class PlotlyPlotter(PlotterBase):
                 range=[-residual_limit, residual_limit],
                 tickmode='array',
                 tickvals=[-residual_tick_limit, 0.0, residual_tick_limit],
+                scaleanchor='y',
+                scaleratio=1,
                 zeroline=False,
                 row=layout.residual_row,
                 col=1,

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -51,6 +51,13 @@ BRAGG_TICK_COLORS = (
 NICE_AXIS_FRACTIONS = (1.0, 2.0, 5.0, 10.0)
 DISPLAY_TICK_FRACTIONS = (1.0, 2.0, 2.5, 4.0, 5.0, 7.5, 10.0)
 PLOTLY_HEIGHT_PER_UNIT = 24
+BRAGG_TICK_MARKER_SIZE = 12
+BRAGG_TICK_MARKER_LINE_WIDTH = 1
+BRAGG_TICK_SYMBOL_HEIGHT_SCALE = 1.4
+COMPOSITE_VERTICAL_SPACING = 0.03
+COMPOSITE_MARGIN_RIGHT = 30
+COMPOSITE_MARGIN_TOP = 40
+COMPOSITE_MARGIN_BOTTOM = 45
 
 
 @dataclass(frozen=True)
@@ -58,11 +65,9 @@ class PowderCompositeRows:
     """Resolved row layout for the composite powder figure."""
 
     row_count: int
-    normalized_heights: list[float]
+    row_heights: list[float]
     bragg_row: int | None
     residual_row: int | None
-    total_weight: float
-    baseline_weight: float
 
 
 class PlotlyPlotter(PlotterBase):
@@ -646,7 +651,7 @@ class PlotlyPlotter(PlotterBase):
         for idx, x_value in enumerate(tick_set.x):
             hover_text.append(
                 f'Bragg peaks: {tick_set.phase_id}<br>'
-                f'hkl: ({int(tick_set.h[idx])} {int(tick_set.k[idx])} '
+                f'Miller indices: ({int(tick_set.h[idx])} {int(tick_set.k[idx])} '
                 f'{int(tick_set.ell[idx])})<br>'
                 f'x: {float(x_value):.6g}<br>'
                 # f'F²cal:{float(tick_set.f_squared_calc[idx]):.6g}<br>'
@@ -660,11 +665,11 @@ class PlotlyPlotter(PlotterBase):
             mode='markers',
             marker={
                 'symbol': 'line-ns-open',
-                'size': 12,
-                'line': {'width': 1},
+                'size': BRAGG_TICK_MARKER_SIZE,
+                'line': {'width': BRAGG_TICK_MARKER_LINE_WIDTH},
                 'color': color,
             },
-            name=f'Bragg peaks ({tick_set.phase_id})',
+            name=f'Bragg peaks: {tick_set.phase_id}',
             text=hover_text,
             hoverlabel={
                 'font': {'color': 'white'},
@@ -704,23 +709,73 @@ class PlotlyPlotter(PlotterBase):
         return DISPLAY_TICK_FRACTIONS[0] * base
 
     @staticmethod
-    def _scaled_bragg_row_height(plot_spec: PowderMeasVsCalcSpec) -> float:
-        """
-        Return Bragg-row weight for the current number of phases.
-        """
-        phase_count = len(plot_spec.bragg_tick_sets)
-        if phase_count == 0:
-            return 0.0
+    def _base_composite_height_pixels(plot_spec: PowderMeasVsCalcSpec) -> float:
+        """Return the baseline figure height for a single-phase plot."""
+        if plot_spec.height is None:
+            return float(DEFAULT_HEIGHT * PLOTLY_HEIGHT_PER_UNIT)
+        return float(plot_spec.height)
 
-        return plot_spec.bragg_peaks_height_fraction * phase_count
+    @staticmethod
+    def _composite_plot_area_height(full_height: float) -> float:
+        """Return the drawable plot area height after vertical margins."""
+        return max(full_height - COMPOSITE_MARGIN_TOP - COMPOSITE_MARGIN_BOTTOM, 1.0)
+
+    @staticmethod
+    def _subplot_available_height_fraction(row_count: int) -> float:
+        """Return the fraction of plot height available for subplot rows."""
+        return 1.0 - COMPOSITE_VERTICAL_SPACING * max(row_count - 1, 0)
+
+    @staticmethod
+    def _bragg_tick_symbol_height_pixels() -> float:
+        """Return rendered pixel height for one Bragg tick marker."""
+        return (
+            BRAGG_TICK_MARKER_SIZE * BRAGG_TICK_SYMBOL_HEIGHT_SCALE
+            + BRAGG_TICK_MARKER_LINE_WIDTH
+        )
+
+    @staticmethod
+    def _bragg_row_height_pixels(plot_spec: PowderMeasVsCalcSpec) -> float:
+        """Return the exact Bragg-row pixel height for the current phases."""
+        return float(
+            len(plot_spec.bragg_tick_sets)
+            * PlotlyPlotter._bragg_tick_symbol_height_pixels()
+        )
+
+    @classmethod
+    def _baseline_non_bragg_row_heights(
+        cls,
+        plot_spec: PowderMeasVsCalcSpec,
+        row_count: int,
+        has_bragg_ticks: bool,
+        has_residual: bool,
+    ) -> tuple[float, float | None]:
+        """Return baseline main and residual row heights in pixels."""
+        baseline_height = cls._base_composite_height_pixels(plot_spec)
+        plot_area_height = cls._composite_plot_area_height(baseline_height)
+        available_row_pixels = plot_area_height * cls._subplot_available_height_fraction(row_count)
+        baseline_bragg_pixels = float(cls._bragg_tick_symbol_height_pixels() if has_bragg_ticks else 0)
+        non_bragg_pixels = max(available_row_pixels - baseline_bragg_pixels, 1.0)
+
+        if not has_residual:
+            return non_bragg_pixels, None
+
+        main_pixels = non_bragg_pixels / (1.0 + plot_spec.residual_height_fraction)
+        residual_pixels = main_pixels * plot_spec.residual_height_fraction
+        return main_pixels, residual_pixels
 
     @staticmethod
     def _get_powder_composite_rows(plot_spec: PowderMeasVsCalcSpec) -> PowderCompositeRows:
         """Resolve subplot rows for the composite powder figure."""
         has_bragg_ticks = bool(plot_spec.bragg_tick_sets)
         has_residual = plot_spec.y_resid is not None
-        row_heights = [1.0]
-        baseline_weight = 1.0
+        row_count = 1 + int(has_bragg_ticks) + int(has_residual)
+        main_row_height, residual_row_height = PlotlyPlotter._baseline_non_bragg_row_heights(
+            plot_spec=plot_spec,
+            row_count=row_count,
+            has_bragg_ticks=has_bragg_ticks,
+            has_residual=has_residual,
+        )
+        row_heights = [main_row_height]
         bragg_row = None
         residual_row = None
         next_row = 2
@@ -728,36 +783,35 @@ class PlotlyPlotter(PlotterBase):
         if has_bragg_ticks:
             bragg_row = next_row
             next_row += 1
-            row_heights.append(PlotlyPlotter._scaled_bragg_row_height(plot_spec))
-            baseline_weight += plot_spec.bragg_peaks_height_fraction
+            row_heights.append(PlotlyPlotter._bragg_row_height_pixels(plot_spec))
         if has_residual:
             residual_row = next_row
-            row_heights.append(plot_spec.residual_height_fraction)
-            baseline_weight += plot_spec.residual_height_fraction
+            row_heights.append(residual_row_height if residual_row_height is not None else 1.0)
 
-        total_height = sum(row_heights)
-        normalized_heights = [row_height / total_height for row_height in row_heights]
         return PowderCompositeRows(
-            row_count=1 + int(has_bragg_ticks) + int(has_residual),
-            normalized_heights=normalized_heights,
+            row_count=row_count,
+            row_heights=row_heights,
             bragg_row=bragg_row,
             residual_row=residual_row,
-            total_weight=total_height,
-            baseline_weight=baseline_weight,
         )
 
-    @staticmethod
+    @classmethod
     def _composite_figure_height(
+        cls,
         plot_spec: PowderMeasVsCalcSpec,
         layout: PowderCompositeRows,
-    ) -> int:
-        """Return figure height scaled by Bragg-row growth."""
-        if plot_spec.height is None:
-            base_pixels = DEFAULT_HEIGHT * PLOTLY_HEIGHT_PER_UNIT
-        else:
-            base_pixels = plot_spec.height
-        scaled_pixels = np.ceil(base_pixels * layout.total_weight / layout.baseline_weight)
-        return int(scaled_pixels)
+    ) -> float:
+        """Return figure height with Bragg growth from a single-phase baseline."""
+        base_pixels = cls._base_composite_height_pixels(plot_spec)
+        phase_count = len(plot_spec.bragg_tick_sets)
+        if phase_count <= 1:
+            return base_pixels
+
+        added_bragg_pixels = float(
+            (phase_count - 1) * cls._bragg_tick_symbol_height_pixels()
+        )
+        growth_pixels = added_bragg_pixels / cls._subplot_available_height_fraction(layout.row_count)
+        return base_pixels + growth_pixels
 
     @classmethod
     def _get_residual_limit(cls, plot_spec: PowderMeasVsCalcSpec) -> float:
@@ -801,8 +855,8 @@ class PlotlyPlotter(PlotterBase):
             rows=layout.row_count,
             cols=1,
             shared_xaxes=True,
-            vertical_spacing=0.04,
-            row_heights=layout.normalized_heights,
+            vertical_spacing=COMPOSITE_VERTICAL_SPACING,
+            row_heights=layout.row_heights,
         )
 
         fig.add_trace(self._get_powder_trace(plot_spec.x, plot_spec.y_meas, 'meas'), row=1, col=1)
@@ -833,9 +887,9 @@ class PlotlyPlotter(PlotterBase):
             height=self._composite_figure_height(plot_spec, layout),
             margin={
                 'autoexpand': True,
-                'r': 30,
-                't': 40,
-                'b': 45,
+                'r': COMPOSITE_MARGIN_RIGHT,
+                't': COMPOSITE_MARGIN_TOP,
+                'b': COMPOSITE_MARGIN_BOTTOM,
             },
             title={'text': plot_spec.title},
             legend={

--- a/src/easydiffraction/display/plotters/plotly.py
+++ b/src/easydiffraction/display/plotters/plotly.py
@@ -385,6 +385,7 @@ class PlotlyPlotter(PlotterBase):
             line=line,
             mode=mode,
             name=name,
+            hovertemplate=f'{name}<br>x: %{{x}}<br>y: %{{y}}<extra></extra>',
         )
 
     @staticmethod
@@ -643,16 +644,14 @@ class PlotlyPlotter(PlotterBase):
         y = np.full(tick_set.x.shape, row_y, dtype=float)
         hover_text = []
         for idx, x_value in enumerate(tick_set.x):
-            hkl_text = (
-                f'hkl: ({int(tick_set.h[idx])} '
-                f'{int(tick_set.k[idx])} {int(tick_set.ell[idx])})<br>'
-            )
             hover_text.append(
-                f'phase_id: {tick_set.phase_id}<br>'
-                f'{hkl_text}'
+                f'Bragg peaks: {tick_set.phase_id}<br>'
+                f'hkl: ({int(tick_set.h[idx])} {int(tick_set.k[idx])} '
+                f'{int(tick_set.ell[idx])})<br>'
                 f'x: {float(x_value):.6g}<br>'
-                f'f_squared_calc: {float(tick_set.f_squared_calc[idx]):.6g}<br>'
-                f'f_calc: {float(tick_set.f_calc[idx]):.6g}<extra></extra>'
+                # f'F²cal:{float(tick_set.f_squared_calc[idx]):.6g}<br>'
+                # f'Fcalc:{float(tick_set.f_calc[idx]):.6g}'
+                '<extra></extra>'
             )
 
         return go.Scatter(
@@ -662,13 +661,16 @@ class PlotlyPlotter(PlotterBase):
             marker={
                 'symbol': 'line-ns-open',
                 'size': 12,
-                'line': {'color': color, 'width': 1},
+                'line': {'width': 1},
                 'color': color,
             },
-            name=f'Bragg ({tick_set.phase_id})',
+            name=f'Bragg peaks ({tick_set.phase_id})',
             text=hover_text,
+            hoverlabel={
+                'font': {'color': 'white'},
+                'bordercolor': 'white',
+            },
             hovertemplate='%{text}',
-            showlegend=False,
         )
 
     @staticmethod

--- a/src/easydiffraction/display/plotting.py
+++ b/src/easydiffraction/display/plotting.py
@@ -81,6 +81,15 @@ class _MeasVsCalcPlotOptions:
     x: object | None = None
 
 
+@dataclass(frozen=True)
+class _PowderMeasVsCalcSeries:
+    """Filtered y-series for a composite powder plot."""
+
+    y_meas: np.ndarray
+    y_calc: np.ndarray
+    y_bkg: np.ndarray | None = None
+
+
 class Plotter(RendererBase):
     """User-facing plotting facade backed by concrete plotters."""
 
@@ -1195,14 +1204,18 @@ class Plotter(RendererBase):
             else None
         )
 
+        powder_series = _PowderMeasVsCalcSeries(
+            y_meas=y_meas,
+            y_calc=y_calc,
+            y_bkg=y_bkg,
+        )
+
         if sample_form == SampleFormEnum.POWDER and scattering_type == ScatteringTypeEnum.BRAGG:
             self._plot_powder_bragg_meas_vs_calc(
                 experiment=experiment,
                 expt_name=expt_name,
                 ctx=ctx,
-                y_meas=y_meas,
-                y_bkg=y_bkg,
-                y_calc=y_calc,
+                series=powder_series,
                 plot_options=plot_options,
                 title=title,
             )
@@ -1251,9 +1264,7 @@ class Plotter(RendererBase):
         experiment: object,
         expt_name: str,
         ctx: dict[str, object],
-        y_meas: np.ndarray,
-        y_bkg: np.ndarray | None,
-        y_calc: np.ndarray,
+        series: _PowderMeasVsCalcSeries,
         plot_options: _MeasVsCalcPlotOptions,
         title: str,
     ) -> None:
@@ -1261,7 +1272,7 @@ class Plotter(RendererBase):
         Render the composite powder Bragg measured-vs-calculated plot.
         """
         show_residual = True if plot_options.show_residual is None else plot_options.show_residual
-        y_resid = y_meas - y_calc if show_residual else None
+        y_resid = series.y_meas - series.y_calc if show_residual else None
         if np.asarray(ctx['x_filtered']).size == 0:
             bragg_tick_sets = ()
         else:
@@ -1274,8 +1285,8 @@ class Plotter(RendererBase):
             )
         plot_spec = PowderMeasVsCalcSpec(
             x=ctx['x_filtered'],
-            y_meas=y_meas,
-            y_calc=y_calc,
+            y_meas=series.y_meas,
+            y_calc=series.y_calc,
             y_resid=y_resid,
             bragg_tick_sets=bragg_tick_sets,
             axes_labels=ctx['axes_labels'],
@@ -1283,7 +1294,7 @@ class Plotter(RendererBase):
             residual_height_fraction=DEFAULT_RESID_HEIGHT,
             bragg_peaks_height_fraction=DEFAULT_BRAGG_ROW,
             height=self._composite_plot_height(),
-            y_bkg=y_bkg,
+            y_bkg=series.y_bkg,
         )
         self._backend.plot_powder_meas_vs_calc(plot_spec=plot_spec)
 

--- a/src/easydiffraction/display/plotting.py
+++ b/src/easydiffraction/display/plotting.py
@@ -78,8 +78,6 @@ class _MeasVsCalcPlotOptions:
     x_min: float | None = None
     x_max: float | None = None
     show_residual: bool | None = None
-    residual_height_fraction: float = DEFAULT_RESID_HEIGHT
-    bragg_peaks_height_fraction: float = DEFAULT_BRAGG_ROW
     x: object | None = None
 
 
@@ -467,8 +465,6 @@ class Plotter(RendererBase):
         x_max: float | None = None,
         *,
         show_residual: bool | None = None,
-        residual_height_fraction: float = DEFAULT_RESID_HEIGHT,
-        bragg_peaks_height_fraction: float = DEFAULT_BRAGG_ROW,
         x: object | None = None,
     ) -> None:
         """
@@ -486,12 +482,6 @@ class Plotter(RendererBase):
             When ``None``, powder Bragg plots include the residual by
             default while other measured-vs-calculated plots keep the
             historical no-residual default.
-        residual_height_fraction : float, default=DEFAULT_RESID_HEIGHT
-            Optional. Defaults to 0.25. Residual-row height relative to
-            the main intensity row.
-        bragg_peaks_height_fraction : float, default=DEFAULT_BRAGG_ROW
-            Optional. Defaults to 0.15. Bragg-tick-row height relative
-            to the main intensity row.
         x : object | None, default=None
             Optional explicit x-axis data to override stored values.
         """
@@ -501,8 +491,6 @@ class Plotter(RendererBase):
             x_min=x_min,
             x_max=x_max,
             show_residual=show_residual,
-            residual_height_fraction=residual_height_fraction,
-            bragg_peaks_height_fraction=bragg_peaks_height_fraction,
             x=x,
         )
         self._plot_meas_vs_calc_data(
@@ -1284,8 +1272,8 @@ class Plotter(RendererBase):
             bragg_tick_sets=bragg_tick_sets,
             axes_labels=ctx['axes_labels'],
             title=title,
-            residual_height_fraction=plot_options.residual_height_fraction,
-            bragg_peaks_height_fraction=plot_options.bragg_peaks_height_fraction,
+            residual_height_fraction=DEFAULT_RESID_HEIGHT,
+            bragg_peaks_height_fraction=DEFAULT_BRAGG_ROW,
             height=self._composite_plot_height(),
         )
         self._backend.plot_powder_meas_vs_calc(plot_spec=plot_spec)

--- a/src/easydiffraction/display/plotting.py
+++ b/src/easydiffraction/display/plotting.py
@@ -1188,6 +1188,12 @@ class Plotter(RendererBase):
         y_calc = self._filtered_y_array(
             pattern.intensity_calc, ctx['x_array'], ctx['x_min'], ctx['x_max']
         )
+        y_bkg_raw = getattr(pattern, 'intensity_bkg', None)
+        y_bkg = (
+            self._filtered_y_array(y_bkg_raw, ctx['x_array'], ctx['x_min'], ctx['x_max'])
+            if y_bkg_raw is not None
+            else None
+        )
 
         if sample_form == SampleFormEnum.POWDER and scattering_type == ScatteringTypeEnum.BRAGG:
             self._plot_powder_bragg_meas_vs_calc(
@@ -1195,6 +1201,7 @@ class Plotter(RendererBase):
                 expt_name=expt_name,
                 ctx=ctx,
                 y_meas=y_meas,
+                y_bkg=y_bkg,
                 y_calc=y_calc,
                 plot_options=plot_options,
                 title=title,
@@ -1245,6 +1252,7 @@ class Plotter(RendererBase):
         expt_name: str,
         ctx: dict[str, object],
         y_meas: np.ndarray,
+        y_bkg: np.ndarray | None,
         y_calc: np.ndarray,
         plot_options: _MeasVsCalcPlotOptions,
         title: str,
@@ -1275,6 +1283,7 @@ class Plotter(RendererBase):
             residual_height_fraction=DEFAULT_RESID_HEIGHT,
             bragg_peaks_height_fraction=DEFAULT_BRAGG_ROW,
             height=self._composite_plot_height(),
+            y_bkg=y_bkg,
         )
         self._backend.plot_powder_meas_vs_calc(plot_spec=plot_spec)
 

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -296,6 +296,8 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
     assert fig.layout.xaxis.matches == 'x'
     assert fig.layout.xaxis2.matches == 'x'
     assert fig.layout.xaxis3.matches == 'x'
+    assert fig.layout.yaxis3.scaleanchor == 'y'
+    assert fig.layout.yaxis3.scaleratio == pytest.approx(1.0)
 
     plot_area_height = fig.layout.height - fig.layout.margin.t - fig.layout.margin.b
     main_height = fig.layout.yaxis.domain[1] - fig.layout.yaxis.domain[0]
@@ -555,9 +557,19 @@ def test_plot_powder_meas_vs_calc_keeps_exact_residual_scale_match(monkeypatch):
     )
 
     fig = captured['fig']
-    expected_limit = 0.5 * (3600.0 - 180.0) * 0.25
+    expected_limit = 0.5 * (3600.0 - 0.0) * 0.25
+    assert fig.layout.yaxis2.scaleanchor == 'y'
+    assert fig.layout.yaxis2.scaleratio == pytest.approx(1.0)
+    assert fig.layout.yaxis.range[0] == pytest.approx(0.0)
+    assert fig.layout.yaxis.range[1] == pytest.approx(3600.0)
     assert fig.layout.yaxis2.range[0] == pytest.approx(-expected_limit)
     assert fig.layout.yaxis2.range[1] == pytest.approx(expected_limit)
+    plot_area_height = fig.layout.height - fig.layout.margin.t - fig.layout.margin.b
+    main_pixels = plot_area_height * (fig.layout.yaxis.domain[1] - fig.layout.yaxis.domain[0])
+    residual_pixels = plot_area_height * (fig.layout.yaxis2.domain[1] - fig.layout.yaxis2.domain[0])
+    main_units_per_pixel = (fig.layout.yaxis.range[1] - fig.layout.yaxis.range[0]) / main_pixels
+    residual_units_per_pixel = (fig.layout.yaxis2.range[1] - fig.layout.yaxis2.range[0]) / residual_pixels
+    assert residual_units_per_pixel == pytest.approx(main_units_per_pixel)
     assert list(fig.layout.yaxis2.tickvals) == pytest.approx([-400.0, 0.0, 400.0])
 
 
@@ -590,7 +602,7 @@ def test_plot_powder_meas_vs_calc_clips_large_residual_spikes(monkeypatch):
     )
 
     fig = captured['fig']
-    expected_limit = 0.5 * (3600.0 - 180.0) * 0.25
+    expected_limit = 0.5 * (3600.0 - 0.0) * 0.25
     assert fig.layout.yaxis2.range[0] == pytest.approx(-expected_limit)
     assert fig.layout.yaxis2.range[1] == pytest.approx(expected_limit)
     assert list(fig.layout.yaxis2.tickvals) == pytest.approx([-400.0, 0.0, 400.0])

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -297,16 +297,20 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
     assert fig.layout.xaxis2.matches == 'x'
     assert fig.layout.xaxis3.matches == 'x'
 
+    plot_area_height = fig.layout.height - fig.layout.margin.t - fig.layout.margin.b
     main_height = fig.layout.yaxis.domain[1] - fig.layout.yaxis.domain[0]
     bragg_height = fig.layout.yaxis2.domain[1] - fig.layout.yaxis2.domain[0]
     residual_height = fig.layout.yaxis3.domain[1] - fig.layout.yaxis3.domain[0]
     assert residual_height == pytest.approx(main_height * 0.25)
-    assert bragg_height == pytest.approx(
-        main_height * pp.PlotlyPlotter._scaled_bragg_row_height(plot_spec)
+    assert plot_area_height * bragg_height == pytest.approx(
+        2 * pp.PlotlyPlotter._bragg_tick_symbol_height_pixels()
     )
 
     bragg_traces = [trace for trace in fig.data if trace.name.startswith('Bragg')]
-    assert [trace.name for trace in bragg_traces] == ['Bragg (phase-a)', 'Bragg (phase-b)']
+    assert [trace.name for trace in bragg_traces] == [
+        'Bragg peaks: phase-a',
+        'Bragg peaks: phase-b',
+    ]
     assert list(bragg_traces[0].y) == [1.0]
     assert list(bragg_traces[1].y) == [2.0]
     assert list(fig.layout.yaxis2.ticktext) == ['phase-a', 'phase-b']
@@ -315,11 +319,11 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
     assert fig.layout.yaxis3.title.text is None
     assert fig.layout.yaxis3.zeroline is False
     assert fig.layout.xaxis3.title.text == '2θ (degree)'
-    assert 'hkl: (1 0 1)' in bragg_traces[0].text[0]
-    assert 'f_squared_calc: 100' in bragg_traces[0].text[0]
+    assert 'Miller indices: (1 0 1)' in bragg_traces[0].text[0]
+    assert 'Bragg peaks: phase-a' in bragg_traces[0].text[0]
 
 
-def test_scaled_bragg_row_height_scales_linearly_with_phase_count():
+def test_bragg_row_height_pixels_scale_linearly_with_phase_count():
     from easydiffraction.display.plotters.base import BraggTickSet
     from easydiffraction.display.plotters.base import PowderMeasVsCalcSpec
     from easydiffraction.display.plotters.plotly import PlotlyPlotter
@@ -370,10 +374,11 @@ def test_scaled_bragg_row_height_scales_linearly_with_phase_count():
         height=single_phase.height,
     )
 
-    single_height = PlotlyPlotter._scaled_bragg_row_height(single_phase)
-    two_phase_height = PlotlyPlotter._scaled_bragg_row_height(two_phase)
-    assert single_height == pytest.approx(0.10)
-    assert two_phase_height == pytest.approx(0.20)
+    symbol_height = PlotlyPlotter._bragg_tick_symbol_height_pixels()
+    single_height = PlotlyPlotter._bragg_row_height_pixels(single_phase)
+    two_phase_height = PlotlyPlotter._bragg_row_height_pixels(two_phase)
+    assert single_height == pytest.approx(symbol_height)
+    assert two_phase_height == pytest.approx(2 * symbol_height)
 
 
 def test_plot_powder_meas_vs_calc_grows_total_height_for_many_phases(monkeypatch):
@@ -423,7 +428,8 @@ def test_plot_powder_meas_vs_calc_grows_total_height_for_many_phases(monkeypatch
 
     def row_height_pixels(fig, axis_name: str) -> float:
         axis = getattr(fig.layout, axis_name)
-        return fig.layout.height * (axis.domain[1] - axis.domain[0])
+        plot_area_height = fig.layout.height - fig.layout.margin.t - fig.layout.margin.b
+        return plot_area_height * (axis.domain[1] - axis.domain[0])
 
     assert multi_fig.layout.height > single_fig.layout.height
     assert row_height_pixels(multi_fig, 'yaxis') == pytest.approx(

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -307,6 +307,23 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
         2 * pp.PlotlyPlotter._bragg_tick_symbol_height_pixels()
     )
 
+    expected_hovertemplate = (
+        'x: %{x}<br>'
+        'Imeas: %{customdata[0]}<br>'
+        'Icalc: %{customdata[1]}<br>'
+        'Imeas - Icalc: %{customdata[2]}'
+        '<extra></extra>'
+    )
+    meas_trace = next(trace for trace in fig.data if trace.name == 'Measured (Imeas)')
+    calc_trace = next(trace for trace in fig.data if trace.name == 'Total calculated (Icalc)')
+    residual_trace = next(trace for trace in fig.data if trace.name == 'Residual (Imeas - Icalc)')
+    assert meas_trace.hovertemplate == expected_hovertemplate
+    assert calc_trace.hovertemplate == expected_hovertemplate
+    assert residual_trace.hovertemplate == expected_hovertemplate
+    assert list(meas_trace.customdata[0]) == pytest.approx([10.0, 9.0, 1.0])
+    assert list(calc_trace.customdata[0]) == pytest.approx([10.0, 9.0, 1.0])
+    assert list(residual_trace.customdata[0]) == pytest.approx([10.0, 9.0, 1.0])
+
     bragg_traces = [trace for trace in fig.data if trace.name.startswith('Bragg')]
     assert [trace.name for trace in bragg_traces] == [
         'Bragg peaks: phase-a',

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -113,6 +113,7 @@ def test_get_trace_and_plot(monkeypatch):
     assert hasattr(trace, 'kwargs')
     assert trace.kwargs['x'] == x
     assert trace.kwargs['y'] == y
+    assert trace.kwargs['line']['width'] == pp.CALCULATED_LINE_WIDTH
 
     # Exercise plot_powder (non-PyCharm, display path)
     plotter.plot_powder(
@@ -320,6 +321,9 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
     assert meas_trace.hovertemplate == expected_hovertemplate
     assert calc_trace.hovertemplate == expected_hovertemplate
     assert residual_trace.hovertemplate == expected_hovertemplate
+    assert meas_trace.line.width == pp.MEASURED_LINE_WIDTH
+    assert calc_trace.line.width == pp.CALCULATED_LINE_WIDTH
+    assert residual_trace.line.width == pp.RESIDUAL_LINE_WIDTH
     assert list(meas_trace.customdata[0]) == pytest.approx([10.0, 9.0, 1.0])
     assert list(calc_trace.customdata[0]) == pytest.approx([10.0, 9.0, 1.0])
     assert list(residual_trace.customdata[0]) == pytest.approx([10.0, 9.0, 1.0])
@@ -395,6 +399,7 @@ def test_plot_powder_meas_vs_calc_adds_background_curve(monkeypatch):
     assert list(background_trace.y) == pytest.approx([1.5, 1.5, 1.5])
     assert background_trace.mode == 'lines'
     assert background_trace.line.color == pp.DEFAULT_COLORS['bkg']
+    assert background_trace.line.width == pp.BACKGROUND_LINE_WIDTH
     assert meas_trace.legendrank < background_trace.legendrank < calc_trace.legendrank
     assert residual_trace.legendrank > calc_trace.legendrank
     for trace in (meas_trace, background_trace, calc_trace, residual_trace):

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -237,10 +237,9 @@ def test_get_bragg_tick_trace_includes_peak_metadata():
     assert trace.mode == 'markers'
     assert trace.marker.symbol == 'line-ns-open'
     assert trace.hovertemplate == '%{text}'
-    assert 'phase_id: phase-a' in trace.text[0]
-    assert 'hkl: (1 0 1)' in trace.text[0]
-    assert 'f_squared_calc: 100' in trace.text[0]
-    assert 'f_calc: 10' in trace.text[0]
+    assert 'Bragg peaks: phase-a' in trace.text[0]
+    assert 'Miller indices: (1 0 1)' in trace.text[0]
+    assert 'x: 1.5' in trace.text[0]
 
 
 def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch):

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -237,9 +237,9 @@ def test_get_bragg_tick_trace_includes_peak_metadata():
     assert trace.mode == 'markers'
     assert trace.marker.symbol == 'line-ns-open'
     assert trace.hovertemplate == '%{text}'
-    assert 'Bragg peaks: phase-a' in trace.text[0]
+    assert 'phase-a' in trace.text[0]
     assert 'Miller indices: (1 0 1)' in trace.text[0]
-    assert 'x: 1.5' in trace.text[0]
+    assert 'x: 1.50' in trace.text[0]
 
 
 def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch):
@@ -308,10 +308,10 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
     )
 
     expected_hovertemplate = (
-        'x: %{x}<br>'
-        'Imeas: %{customdata[0]}<br>'
-        'Icalc: %{customdata[1]}<br>'
-        'Imeas - Icalc: %{customdata[2]}'
+        'x: %{x:,.2f}<br>'
+        'Imeas: %{customdata[0]:,.2f}<br>'
+        'Icalc: %{customdata[1]:,.2f}<br>'
+        'Imeas - Icalc: %{customdata[2]:,.2f}'
         '<extra></extra>'
     )
     meas_trace = next(trace for trace in fig.data if trace.name == 'Measured (Imeas)')
@@ -338,7 +338,63 @@ def test_plot_powder_meas_vs_calc_creates_synced_three_panel_figure(monkeypatch)
     assert fig.layout.yaxis3.zeroline is False
     assert fig.layout.xaxis3.title.text == '2θ (degree)'
     assert 'Miller indices: (1 0 1)' in bragg_traces[0].text[0]
-    assert 'Bragg peaks: phase-a' in bragg_traces[0].text[0]
+    assert 'phase-a' in bragg_traces[0].text[0]
+
+
+def test_plot_powder_meas_vs_calc_adds_background_curve(monkeypatch):
+    import easydiffraction.display.plotters.plotly as pp
+
+    from easydiffraction.display.plotters.base import BraggTickSet
+    from easydiffraction.display.plotters.base import PowderMeasVsCalcSpec
+
+    captured = {}
+
+    def fake_show_figure(self, fig):
+        captured['fig'] = fig
+
+    monkeypatch.setattr(pp.PlotlyPlotter, '_show_figure', fake_show_figure)
+
+    plot_spec = PowderMeasVsCalcSpec(
+        x=np.array([1.0, 2.0, 3.0]),
+        y_meas=np.array([10.0, 12.0, 11.0]),
+        y_calc=np.array([9.0, 11.0, 10.5]),
+        y_resid=np.array([1.0, 1.0, 0.5]),
+        bragg_tick_sets=(
+            BraggTickSet(
+                phase_id='phase-a',
+                x=np.array([1.5]),
+                h=np.array([1]),
+                k=np.array([0]),
+                ell=np.array([1]),
+                f_squared_calc=np.array([100.0]),
+                f_calc=np.array([10.0]),
+            ),
+        ),
+        axes_labels=['2θ (degree)', 'Intensity (arb. units)'],
+        title='Powder',
+        residual_height_fraction=0.25,
+        bragg_peaks_height_fraction=0.10,
+        height=None,
+        y_bkg=np.array([1.5, 1.5, 1.5]),
+    )
+
+    plotter = pp.PlotlyPlotter()
+    plotter.plot_powder_meas_vs_calc(plot_spec=plot_spec)
+
+    fig = captured['fig']
+    assert len(fig.data) == 5
+    background_trace = next(trace for trace in fig.data if trace.name == 'Background (Ibkg)')
+    meas_trace = next(trace for trace in fig.data if trace.name == 'Measured (Imeas)')
+    calc_trace = next(trace for trace in fig.data if trace.name == 'Total calculated (Icalc)')
+    residual_trace = next(trace for trace in fig.data if trace.name == 'Residual (Imeas - Icalc)')
+    assert list(background_trace.y) == pytest.approx([1.5, 1.5, 1.5])
+    assert background_trace.mode == 'lines'
+    assert background_trace.line.color == pp.DEFAULT_COLORS['bkg']
+    assert meas_trace.legendrank < background_trace.legendrank < calc_trace.legendrank
+    assert residual_trace.legendrank > calc_trace.legendrank
+    for trace in (meas_trace, background_trace, calc_trace, residual_trace):
+        assert 'Ibkg: %{customdata[1]' in trace.hovertemplate
+        assert list(trace.customdata[0]) == pytest.approx([10.0, 1.5, 9.0, 1.0])
 
 
 def test_bragg_row_height_pixels_scale_linearly_with_phase_count():

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -566,9 +566,13 @@ def test_plot_powder_meas_vs_calc_keeps_exact_residual_scale_match(monkeypatch):
     assert fig.layout.yaxis2.range[1] == pytest.approx(expected_limit)
     plot_area_height = fig.layout.height - fig.layout.margin.t - fig.layout.margin.b
     main_pixels = plot_area_height * (fig.layout.yaxis.domain[1] - fig.layout.yaxis.domain[0])
-    residual_pixels = plot_area_height * (fig.layout.yaxis2.domain[1] - fig.layout.yaxis2.domain[0])
+    residual_pixels = plot_area_height * (
+        fig.layout.yaxis2.domain[1] - fig.layout.yaxis2.domain[0]
+    )
     main_units_per_pixel = (fig.layout.yaxis.range[1] - fig.layout.yaxis.range[0]) / main_pixels
-    residual_units_per_pixel = (fig.layout.yaxis2.range[1] - fig.layout.yaxis2.range[0]) / residual_pixels
+    residual_units_per_pixel = (
+        fig.layout.yaxis2.range[1] - fig.layout.yaxis2.range[0]
+    ) / residual_pixels
     assert residual_units_per_pixel == pytest.approx(main_units_per_pixel)
     assert list(fig.layout.yaxis2.tickvals) == pytest.approx([-400.0, 0.0, 400.0])
 

--- a/tests/unit/easydiffraction/display/plotters/test_plotly.py
+++ b/tests/unit/easydiffraction/display/plotters/test_plotly.py
@@ -383,6 +383,11 @@ def test_plot_powder_meas_vs_calc_adds_background_curve(monkeypatch):
 
     fig = captured['fig']
     assert len(fig.data) == 5
+    assert [trace.name for trace in fig.data[:3]] == [
+        'Measured (Imeas)',
+        'Background (Ibkg)',
+        'Total calculated (Icalc)',
+    ]
     background_trace = next(trace for trace in fig.data if trace.name == 'Background (Ibkg)')
     meas_trace = next(trace for trace in fig.data if trace.name == 'Measured (Imeas)')
     calc_trace = next(trace for trace in fig.data if trace.name == 'Total calculated (Icalc)')

--- a/tests/unit/easydiffraction/display/test_plotting.py
+++ b/tests/unit/easydiffraction/display/test_plotting.py
@@ -492,6 +492,18 @@ def test_plot_meas_vs_calc_skips_bragg_ticks_when_filtered_pattern_is_empty():
     assert call.bragg_tick_sets == ()
 
 
+def test_plot_meas_vs_calc_does_not_accept_layout_fraction_overrides():
+    from easydiffraction.display.plotting import Plotter
+
+    plotter = Plotter()
+
+    with pytest.raises(TypeError, match='residual_height_fraction'):
+        plotter.plot_meas_vs_calc('E1', residual_height_fraction=0.20)
+
+    with pytest.raises(TypeError, match='bragg_peaks_height_fraction'):
+        plotter.plot_meas_vs_calc('E1', bragg_peaks_height_fraction=0.20)
+
+
 def test_plot_meas_vs_calc_keeps_single_crystal_routing():
     import numpy as np
 

--- a/tests/unit/easydiffraction/display/test_plotting.py
+++ b/tests/unit/easydiffraction/display/test_plotting.py
@@ -290,6 +290,7 @@ def test_plot_meas_vs_calc_routes_powder_bragg_to_composite_backend():
         two_theta = np.array([0.0, 1.0, 2.0, 3.0])
         d_spacing = two_theta
         intensity_meas = np.array([10.0, 20.0, 30.0, 40.0])
+        intensity_bkg = np.array([1.0, 2.0, 3.0, 4.0])
         intensity_calc = np.array([9.0, 18.0, 27.0, 39.0])
 
     class Refln:
@@ -324,6 +325,7 @@ def test_plot_meas_vs_calc_routes_powder_bragg_to_composite_backend():
     call = captured['powder_meas_vs_calc']
     assert np.allclose(call.x, np.array([1.0, 2.0]))
     assert np.allclose(call.y_meas, np.array([20.0, 30.0]))
+    assert np.allclose(call.y_bkg, np.array([2.0, 3.0]))
     assert np.allclose(call.y_calc, np.array([18.0, 27.0]))
     assert np.allclose(call.y_resid, np.array([2.0, 3.0]))
     assert [tick_set.phase_id for tick_set in call.bragg_tick_sets] == [


### PR DESCRIPTION
Updates Plotly powder measured-vs-calculated plots with improved subplot sizing, matched residual scaling, clearer shared hover labels, explicit trace styling, and an optional background curve. The layout now handles Bragg tick rows more predictably while keeping the main chart easier to read.