### PR TITLE
Update CIF_URL to new GitHub release link

### DIFF
--- a/tests/integration/scipp-analysis/dream/conftest.py
+++ b/tests/integration/scipp-analysis/dream/conftest.py
@@ -14,7 +14,7 @@ import pytest
 from pooch import retrieve
 
 # Remote CIF file URL (regenerated nightly by scipp reduction pipeline)
-CIF_URL = 'https://pub-6c25ef91903d4301a3338bd53b370098.r2.dev/dream_reduced.cif'
+CIF_URL = 'https://github.com/scipp/ess/releases/download/reduced_data_nightly/dream_reduced.cif'
 
 # Expected datablock name in the CIF file
 DATABLOCK_NAME = 'reduced_tof'


### PR DESCRIPTION
We make nightly releases of reduced files on github now, so no need for this R2 bucket :)

https://github.com/scipp/ess/releases/tag/reduced_data_nightly