### PR TITLE
Fix Pixi platform setup in package CI

### DIFF
--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -40,28 +40,24 @@ jobs:
       - name: Init pixi project
         run: pixi init easydiffraction
 
+      # Minimal macOS version needed for resolving scipp wheel
       - name: Set the minimum system requirements
         working-directory: easydiffraction
         run: |
-          pixi project system-requirements add macos 14.0
-          pixi project system-requirements add glibc 2.35
+          pixi workspace platform add linux-64-glibc-2-35=linux-64 --glibc 2.35 --no-install
+          pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
 
-      - name: Add Python 3.14 from Conda
+      - name: Add Python 3.14
         working-directory: easydiffraction
         run: pixi add "python=3.14"
 
+      # GNU Scientific Library (required by diffpy.pdffit2)
+      # libc++ for macOS (required by diffpy.pdffit2)
       - name: Add other Conda dependencies
         working-directory: easydiffraction
         run: |
           pixi add gsl
           pixi add --platform osx-arm64 libcxx
-
-      #- name: Add pycrysfml calculator from custom PyPI index
-      #  working-directory: easydiffraction
-      #  run: |
-      #    echo '' >> pixi.toml
-      #    echo '[pypi-dependencies]' >> pixi.toml
-      #    echo 'pycrysfml = { version = ">=0.2.1", index = "https://easyscience.github.io/pypi/" }' >> pixi.toml
 
       - name: Add easydiffraction (with dev dependencies) from PyPI
         working-directory: easydiffraction

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -40,12 +40,30 @@ jobs:
       - name: Init pixi project
         run: pixi init easydiffraction
 
-      # Minimal macOS version needed for resolving scipp wheel
-      - name: Set the minimum system requirements
+      - name: Configure Pixi platforms
         working-directory: easydiffraction
+        shell: bash
         run: |
-          pixi workspace platform add linux-64-glibc-2-35=linux-64 --glibc 2.35 --no-install
-          pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
+          set -euo pipefail
+
+          case "$RUNNER_OS" in
+            Linux)
+              pixi_platforms='[{ name = "linux-64-glibc-2-35", platform = "linux-64", glibc = "2.35" }]'
+              ;;
+            macOS)
+              pixi_platforms='[{ name = "osx-arm64-macos-14-0", platform = "osx-arm64", macos = "14.0" }]'
+              ;;
+            Windows)
+              pixi_platforms='["win-64"]'
+              ;;
+            *)
+              echo "Unsupported runner OS: $RUNNER_OS"
+              exit 1
+              ;;
+          esac
+
+          PIXI_PLATFORMS="$pixi_platforms" python -c 'import os, pathlib; path = pathlib.Path("pixi.toml"); text = path.read_text(); path.write_text(text.replace(text.split("platforms = ", 1)[1].split("\n", 1)[0], os.environ["PIXI_PLATFORMS"], 1))'
+          pixi workspace platform list
 
       - name: Add Python 3.14
         working-directory: easydiffraction

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,10 +231,25 @@ jobs:
             pixi init easydiffraction_py$py_ver
             cd easydiffraction_py$py_ver
 
-            # Minimal macOS version needed for resolving scipp wheel
-            echo "Set the minimum system requirements"
-            pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
-            pixi workspace platform add linux-64-glibc-2-35=linux-64 --glibc 2.35 --no-install
+            echo "Configure Pixi platforms"
+            case "$RUNNER_OS" in
+              Linux)
+                pixi_platforms='[{ name = "linux-64-glibc-2-35", platform = "linux-64", glibc = "2.35" }]'
+                ;;
+              macOS)
+                pixi_platforms='[{ name = "osx-arm64-macos-14-0", platform = "osx-arm64", macos = "14.0" }]'
+                ;;
+              Windows)
+                pixi_platforms='["win-64"]'
+                ;;
+              *)
+                echo "Unsupported runner OS: $RUNNER_OS"
+                exit 1
+                ;;
+            esac
+
+            PIXI_PLATFORMS="$pixi_platforms" python -c 'import os, pathlib; path = pathlib.Path("pixi.toml"); text = path.read_text(); path.write_text(text.replace(text.split("platforms = ", 1)[1].split("\n", 1)[0], os.environ["PIXI_PLATFORMS"], 1))'
+            pixi workspace platform list
 
             echo "Add Python $py_ver"
             pixi add "python=$py_ver"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,14 +231,17 @@ jobs:
             pixi init easydiffraction_py$py_ver
             cd easydiffraction_py$py_ver
 
-            echo "Setting the minimum system requirements"
-            pixi project system-requirements add macos 14.0
-            pixi project system-requirements add glibc 2.35
+            # Minimal macOS version needed for resolving scipp wheel
+            echo "Set the minimum system requirements"
+            pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
+            pixi workspace platform add linux-64-glibc-2-35=linux-64 --glibc 2.35 --no-install
 
-            echo "Adding Python $py_ver"
+            echo "Add Python $py_ver"
             pixi add "python=$py_ver"
 
-            echo "Adding GNU Scientific Library (required by diffpy.pdffit2)"
+            # Add other Conda dependencies
+            
+            echo "Add GNU Scientific Library (required by diffpy.pdffit2)"
             pixi add gsl
 
             # diffpy.pdffit2 wheel links @rpath/libc++.1.dylib, which must be
@@ -247,14 +250,6 @@ jobs:
             # platform-specific deps so this is a no-op on Linux/Windows.
             echo "Adding libc++ for macOS (required by diffpy.pdffit2)"
             pixi add --platform osx-arm64 libcxx
-
-            # Doing this in a hacky way, as pixi does not support adding 
-            # dependencies from a custom PyPI index with a CLI command without
-            # specifying full wheel name.
-            #echo "Adding pycrysfml from custom PyPI index"
-            #echo '' >> pixi.toml
-            #echo '[pypi-dependencies]' >> pixi.toml
-            #echo 'pycrysfml = { version = ">=0.2.1", index = "https://easyscience.github.io/pypi/" }' >> pixi.toml
 
             echo "Looking for wheel in ../dist/py$py_ver/"
             ls -l "../dist/py$py_ver/"
@@ -267,7 +262,7 @@ jobs:
 
             whl_abs_path="$(python -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "${whl_path[0]}")"
 
-            echo "Adding easydiffraction from: $whl_abs_path"
+            echo "Add easydiffraction from: $whl_abs_path"
             pixi add --pypi "easydiffraction[dev] @ ${whl_abs_path}"
 
             echo "Exiting pixi project directory"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,7 @@ Please make sure you follow the EasyScience organization-wide
 If you are not planning to contribute code, you may want to:
 
 - 🐞 Report a bug — see [Reporting Issues](#11-reporting-issues)
-- 🛡 Report a security issue — see
-  [Security Issues](#12-security-issues)
+- 🛡 Report a security issue — see [Security Issues](#12-security-issues)
 - 💬 Ask a question or start a discussion at
   [Project Discussions](https://github.com/easyscience/diffraction-lib/discussions)
 

--- a/docs/dev/adrs/accepted/iucr-cif-tag-alignment.md
+++ b/docs/dev/adrs/accepted/iucr-cif-tag-alignment.md
@@ -276,8 +276,10 @@ In `analysis/analysis.cif`:
 - Bayesian diagnostics, success/message/iterations/fitting*time,
   `result_kind`, `point_estimate_name`, fit-parameter posterior
   summaries, and the `_alias` / `_constraint` / `_joint_fit` /
-  `\_sequential_fit*`registries — **stay under their current category names**. File-scoping to`analysis/analysis.cif`carries the disambiguation; no`\_easydiffraction\*\*`
-  prefix is added in the default save.
+  `\_sequential_fit*`registries — **stay under their current category
+  names**. File-scoping to`analysis/analysis.cif`carries the
+  disambiguation; no`\_easydiffraction\*\*` prefix is added in the
+  default save.
 - The `_minimizer.*`, `_fitting_mode.*`, `_calculator.*` selectors stay
   under their current names for the same reason.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -266,17 +266,22 @@ nav:
           - LaB6 FCJ asymmetry: verification/pd-neut-cwl_LaB6_fcj-asymmetry.ipynb
           - LaB6 absorption: verification/pd-neut-cwl_LaB6_absorption.ipynb
           - LBCO basic pseudo-Voigt: verification/pd-neut-cwl_LBCO_basic.ipynb
-          - LBCO preferred orientation: verification/pd-neut-cwl_LBCO_preferred-orientation.ipynb
+          - LBCO preferred orientation:
+              verification/pd-neut-cwl_LBCO_preferred-orientation.ipynb
           - PbSO4 basic pseudo-Voigt: verification/pd-neut-cwl_PbSO4_basic.ipynb
-          - PbSO4 Berar-Baldinozzi asymmetry: verification/pd-neut-cwl_PbSO4_beba-asymmetry.ipynb
+          - PbSO4 Berar-Baldinozzi asymmetry:
+              verification/pd-neut-cwl_PbSO4_beba-asymmetry.ipynb
           - Y2O3 isotropic ADPs: verification/pd-neut-cwl_Y2O3_isotropic-adp.ipynb
           - Y2O3 beta ADPs: verification/pd-neut-cwl_Y2O3_beta-adp.ipynb
       - Powder, neutron, time-of-flight:
           - Fe pseudo-Voigt profile: verification/pd-neut-tof_Fe_pseudo-voigt.ipynb
-          - NCAF Jorgensen-Von Dreele (Gaussian): verification/pd-neut-tof_NCAF_jorgensen-von-dreele.ipynb
+          - NCAF Jorgensen-Von Dreele (Gaussian):
+              verification/pd-neut-tof_NCAF_jorgensen-von-dreele.ipynb
           - Si Jorgensen profile: verification/pd-neut-tof_Si_jorgensen.ipynb
-          - Si Jorgensen-Von Dreele profile: verification/pd-neut-tof_Si_jorgensen-von-dreele.ipynb
-          - Si Jorgensen-Von Dreele + size/strain: verification/pd-neut-tof_Si_jorgensen-von-dreele-size-strain.ipynb
+          - Si Jorgensen-Von Dreele profile:
+              verification/pd-neut-tof_Si_jorgensen-von-dreele.ipynb
+          - Si Jorgensen-Von Dreele + size/strain:
+              verification/pd-neut-tof_Si_jorgensen-von-dreele-size-strain.ipynb
           - Diamond DREAM (ESS, McStas): verification/pd-neut-tof_diamond_dream.ipynb
       - Powder, X-ray, constant wavelength:
           - LiF single wavelength: verification/pd-xray-cwl_LiF_single.ipynb
@@ -287,13 +292,18 @@ nav:
       - Single crystal:
           - Pr2NiO4 basic (CWL): verification/sc-neut-cwl_Pr2NiO4_basic.ipynb
           - Tb2Ti2O7 basic (CWL): verification/sc-neut-cwl_Tb2Ti2O7_basic.ipynb
-          - Tb2Ti2O7 isotropic extinction (CWL): verification/sc-neut-cwl_Tb2Ti2O7_isotropic-extinction.ipynb
-          - Tb2Ti2O7 anisotropic ADPs (CWL): verification/sc-neut-cwl_Tb2Ti2O7_anisotropic-adp.ipynb
+          - Tb2Ti2O7 isotropic extinction (CWL):
+              verification/sc-neut-cwl_Tb2Ti2O7_isotropic-extinction.ipynb
+          - Tb2Ti2O7 anisotropic ADPs (CWL):
+              verification/sc-neut-cwl_Tb2Ti2O7_anisotropic-adp.ipynb
           - Taurine basic (TOF): verification/sc-neut-tof_taurine_basic.ipynb
       - Total scattering:
-          - Ni gaussian-damped sinc: verification/total-neut-cwl_Ni_gaussian-damped-sinc.ipynb
-          - Si gaussian-damped sinc: verification/total-neut-tof_Si_gaussian-damped-sinc.ipynb
-          - NaCl gaussian-damped sinc: verification/total-xray_NaCl_gaussian-damped-sinc.ipynb
+          - Ni gaussian-damped sinc:
+              verification/total-neut-cwl_Ni_gaussian-damped-sinc.ipynb
+          - Si gaussian-damped sinc:
+              verification/total-neut-tof_Si_gaussian-damped-sinc.ipynb
+          - NaCl gaussian-damped sinc:
+              verification/total-xray_NaCl_gaussian-damped-sinc.ipynb
   - Command-Line:
       - Command-Line: cli/index.md
   - API Reference:


### PR DESCRIPTION
## Summary

- configure CI-created Pixi projects with runner-specific rich platform entries
- avoid solving unqualified macOS/Linux PyPI targets that can fall back to source builds
- format non-Python documentation files with the Prettier version installed by CI

## Verification

- `pixi run nonpy-format-check`
- `git diff --check`
- `pixi run check`
- `pixi run docs-build`
